### PR TITLE
Add support for custom player relative placeholders

### DIFF
--- a/HolographicDisplays/API/com/gmail/filoghost/holographicdisplays/api/HologramsAPI.java
+++ b/HolographicDisplays/API/com/gmail/filoghost/holographicdisplays/api/HologramsAPI.java
@@ -2,6 +2,7 @@ package com.gmail.filoghost.holographicdisplays.api;
 
 import java.util.Collection;
 
+import com.gmail.filoghost.holographicdisplays.api.placeholder.PlayerRelativePlaceholderReplacer;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.plugin.Plugin;
@@ -53,7 +54,22 @@ public class HologramsAPI {
 	public static boolean registerPlaceholder(Plugin plugin, String textPlaceholder, double refreshRate, PlaceholderReplacer replacer) {
 		return BackendAPI.registerPlaceholder(plugin, textPlaceholder, refreshRate, replacer);
 	}
-	
+
+	/**
+	 * Registers a new placeholder that can be used in holograms created with commands. This differs from
+	 * {@link #registerPlaceholder(Plugin, String, double, PlaceholderReplacer)} as it uses the dynamic, per-player
+	 * placeholders. These are placeholders that are unique per player (like {@code playername}
+	 * With this method, you can basically expand the core of HolographicDisplays.
+	 *
+	 * @param plugin the owner plugin of the placeholder
+	 * @param textPlaceholder the text that the placeholder will be associated to (e.g.: "{onlinePlayers}")
+	 * @param refreshRate the refresh rate of the placeholder, in seconds. Keep in mind that the minimum is 0.1 seconds, and that will be rounded to tenths of seconds
+	 * @param replacer the implementation that will return the text to replace the placeholder, where the update() method is called every <b>refreshRate</b> seconds
+	 * @return true if the registration was successfull, false if it was already registered
+	 */
+	public static boolean registerPlaceholder(Plugin plugin, String textPlaceholder, double refreshRate, PlayerRelativePlaceholderReplacer replacer) {
+		return BackendAPI.registerPerPlayerPlaceholder(plugin, textPlaceholder, refreshRate, replacer);
+	}
 	
 	/**
 	 * Finds all the placeholders registered by a given plugin.

--- a/HolographicDisplays/API/com/gmail/filoghost/holographicdisplays/api/placeholder/PlayerRelativePlaceholderReplacer.java
+++ b/HolographicDisplays/API/com/gmail/filoghost/holographicdisplays/api/placeholder/PlayerRelativePlaceholderReplacer.java
@@ -1,0 +1,13 @@
+package com.gmail.filoghost.holographicdisplays.api.placeholder;
+
+import org.bukkit.entity.Player;
+
+public interface PlayerRelativePlaceholderReplacer {
+
+    /**
+     * Called to update a placeholder's replacement.
+     * @param player the player the placeholder is being sent to
+     * @return the replacement
+     */
+    String update(Player player);
+}

--- a/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/HolographicDisplays.java
+++ b/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/HolographicDisplays.java
@@ -4,6 +4,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.gmail.filoghost.holographicdisplays.placeholder.PlaceholdersRegister;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -303,7 +304,16 @@ public class HolographicDisplays extends JavaPlugin {
 			MetricsLite metrics = new MetricsLite(this);
 			metrics.start();
 		} catch (Exception ignore) { }
-		
+
+		// Refresh the player relative replacements when the server is done loading the rest of the plugins
+		Bukkit.getScheduler().scheduleSyncDelayedTask(this, new Runnable() {
+
+			@Override
+			public void run() {
+				PlaceholdersRegister.updatePlayerRelativeReplacers();
+			}
+		});
+
 		// The entities are loaded when the server is ready.
 		Bukkit.getScheduler().scheduleSyncDelayedTask(this, new StartupLoadHologramsTask(), 10L);
 	}

--- a/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/bridge/protocollib/current/ProtocolLibHookImpl.java
+++ b/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/bridge/protocollib/current/ProtocolLibHookImpl.java
@@ -2,6 +2,7 @@ package com.gmail.filoghost.holographicdisplays.bridge.protocollib.current;
 
 import java.util.List;
 
+import com.gmail.filoghost.holographicdisplays.placeholder.PlaceholdersManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Entity;
@@ -130,10 +131,7 @@ public class ProtocolLibHookImpl implements ProtocolLibHook {
 						}
 						
 						String customName = (String) customNameWatchableObject.getValue();
-						if (customName.contains("{player}") || customName.contains("{displayname}")) {
-							customNameWatchableObject.setValue(customName.replace("{player}", player.getName()).replace("{displayname}", player.getDisplayName()));
-						}
-
+						customNameWatchableObject.setValue(PlaceholdersManager.processPlayerRelativeReplacements(player, customName));
 					} else if (packet.getType() == PacketType.Play.Server.SPAWN_ENTITY) {
 
 						WrapperPlayServerSpawnEntity spawnEntityPacket = new WrapperPlayServerSpawnEntity(packet);
@@ -194,8 +192,8 @@ public class ProtocolLibHookImpl implements ProtocolLibHook {
 								}
 								
 								String customName = (String) customNameObject;
-								if (customName.contains("{player}") || customName.contains("{displayname}")) {
-									String replacement = customName.replace("{player}", player.getName()).replace("{displayname}", player.getDisplayName());
+								if (PlaceholdersManager.hasPlayerRelativeReplacements(customName)) {
+									String replacement = PlaceholdersManager.processPlayerRelativeReplacements(player, customName);
 
 									WrappedWatchableObject newWatchableObject;
 									if (MinecraftVersion.isGreaterEqualThan(MinecraftVersion.v1_9)) {

--- a/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/bridge/protocollib/old/ProtocolLibHookImpl.java
+++ b/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/bridge/protocollib/old/ProtocolLibHookImpl.java
@@ -3,6 +3,7 @@ package com.gmail.filoghost.holographicdisplays.bridge.protocollib.old;
 import java.lang.reflect.Constructor;
 import java.util.List;
 
+import com.gmail.filoghost.holographicdisplays.placeholder.PlaceholdersManager;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -86,10 +87,10 @@ public class ProtocolLibHookImpl implements ProtocolLibHook {
 							return;
 						}
 
-						if (customName.contains("{player}") || customName.contains("{displayname}")) {
+						if (PlaceholdersManager.hasPlayerRelativeReplacements(customName)) {
 
 							WrappedDataWatcher dataWatcherClone = dataWatcher.deepClone();
-							dataWatcherClone.setObject(customNameWatcherIndex, customName.replace("{player}", player.getName()).replace("{displayname}", player.getDisplayName()));
+							dataWatcherClone.setObject(customNameWatcherIndex, PlaceholdersManager.processPlayerRelativeReplacements(player, customName));
 							spawnEntityPacket.setMetadata(dataWatcherClone);
 							event.setPacket(spawnEntityPacket.getHandle());
 
@@ -158,12 +159,12 @@ public class ProtocolLibHookImpl implements ProtocolLibHook {
 
 								String customName = (String) customNameObject;
 
-								if (customName.contains("{player}") || customName.contains("{displayname}")) {
+								if (PlaceholdersManager.hasPlayerRelativeReplacements(customName)) {
 
 									entityMetadataPacket = new WrapperPlayServerEntityMetadata(packet.deepClone());
 									List<WrappedWatchableObject> clonedList = entityMetadataPacket.getEntityMetadata();
 									WrappedWatchableObject clonedElement = clonedList.get(i);
-									clonedElement.setValue(customName.replace("{player}", player.getName()).replace("{displayname}", player.getDisplayName()));
+									clonedElement.setValue(PlaceholdersManager.processPlayerRelativeReplacements(player, customName));
 									entityMetadataPacket.setEntityMetadata(clonedList);
 									event.setPacket(entityMetadataPacket.getHandle());
 									return;

--- a/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/object/BackendAPI.java
+++ b/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/object/BackendAPI.java
@@ -2,6 +2,7 @@ package com.gmail.filoghost.holographicdisplays.object;
 
 import java.util.Collection;
 
+import com.gmail.filoghost.holographicdisplays.api.placeholder.PlayerRelativePlaceholderReplacer;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
@@ -10,8 +11,6 @@ import org.bukkit.plugin.Plugin;
 import com.gmail.filoghost.holographicdisplays.HolographicDisplays;
 import com.gmail.filoghost.holographicdisplays.api.Hologram;
 import com.gmail.filoghost.holographicdisplays.api.placeholder.PlaceholderReplacer;
-import com.gmail.filoghost.holographicdisplays.object.PluginHologram;
-import com.gmail.filoghost.holographicdisplays.object.PluginHologramManager;
 import com.gmail.filoghost.holographicdisplays.placeholder.Placeholder;
 import com.gmail.filoghost.holographicdisplays.placeholder.PlaceholdersRegister;
 import com.gmail.filoghost.holographicdisplays.util.Validator;
@@ -35,6 +34,14 @@ public class BackendAPI {
 		Validator.isTrue(refreshRate >= 0, "refreshRate should be positive");
 		Validator.notNull(replacer, "replacer");
 		
+		return PlaceholdersRegister.register(new Placeholder(plugin, textPlaceholder, refreshRate, replacer));
+	}
+
+	public static boolean registerPerPlayerPlaceholder(Plugin plugin, String textPlaceholder, double refreshRate, PlayerRelativePlaceholderReplacer replacer) {
+		Validator.notNull(textPlaceholder, "textPlaceholder");
+		Validator.isTrue(refreshRate >= 0, "refreshRate should be positive");
+		Validator.notNull(replacer, "replacer");
+
 		return PlaceholdersRegister.register(new Placeholder(plugin, textPlaceholder, refreshRate, replacer));
 	}
 

--- a/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/placeholder/Placeholder.java
+++ b/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/placeholder/Placeholder.java
@@ -1,5 +1,6 @@
 package com.gmail.filoghost.holographicdisplays.placeholder;
 
+import com.gmail.filoghost.holographicdisplays.api.placeholder.PlayerRelativePlaceholderReplacer;
 import org.bukkit.plugin.Plugin;
 
 import com.gmail.filoghost.holographicdisplays.api.placeholder.PlaceholderReplacer;
@@ -19,12 +20,24 @@ public class Placeholder {
 	private String currentReplacement;
 	
 	private PlaceholderReplacer replacer;
+
+	private boolean isPlayerRelative = false;
+	private PlayerRelativePlaceholderReplacer playerRelativePlaceholderReplacer;
 	
 	public Placeholder(Plugin owner, String textPlaceholder, double refreshRate, PlaceholderReplacer replacer) {
 		this.owner = owner;
 		this.textPlaceholder = textPlaceholder;
 		this.tenthsToRefresh = refreshRate <= 0.1 ? 1 : (int) (refreshRate * 10.0);
 		this.replacer = replacer;
+		this.currentReplacement = "";
+	}
+
+	public Placeholder(Plugin owner, String textPlaceholder, double refreshRate, PlayerRelativePlaceholderReplacer replacer) {
+		this.owner = owner;
+		this.textPlaceholder = textPlaceholder;
+		this.tenthsToRefresh = refreshRate <= 0.1 ? 1 : (int) (refreshRate * 10.0);
+		this.isPlayerRelative = true;
+		this.playerRelativePlaceholderReplacer = replacer;
 		this.currentReplacement = "";
 	}
 	
@@ -61,10 +74,23 @@ public class Placeholder {
 	}
 
 	public void update() {
-		setCurrentReplacement(replacer.update());
+		if (!isPlayerRelative) {
+			replacer.update();
+		}
 	}
 	
-	
+	public boolean isPlayerRelative() {
+		return isPlayerRelative;
+	}
+
+	public PlayerRelativePlaceholderReplacer getPlayerRelativeReplacer() {
+		return playerRelativePlaceholderReplacer;
+	}
+
+	public void setPlayerRelativePlaceholderReplacer(PlayerRelativePlaceholderReplacer replacer) {
+		this.playerRelativePlaceholderReplacer = replacer;
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		if (obj == null) {

--- a/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/placeholder/PlaceholdersManager.java
+++ b/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/placeholder/PlaceholdersManager.java
@@ -7,7 +7,9 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.gmail.filoghost.holographicdisplays.api.placeholder.PlayerRelativePlaceholderReplacer;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 import com.gmail.filoghost.holographicdisplays.api.placeholder.PlaceholderReplacer;
@@ -37,8 +39,29 @@ public class PlaceholdersManager {
 	private static String extractArgumentFromPlaceholder(Matcher matcher) {
 		return matcher.group(2).trim();
 	}
-	
-	
+
+	public static boolean hasPlayerRelativeReplacements(String line) {
+		for (String placeholder : PlaceholdersRegister.getPlayerRelativeReplacers().keySet()) {
+			if (line.contains(placeholder)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public static String processPlayerRelativeReplacements(Player player, String line) {
+		String updatedLine = line;
+
+		for (Entry<String, PlayerRelativePlaceholderReplacer> replacer : PlaceholdersRegister.getPlayerRelativeReplacers().entrySet()) {
+			if (line.contains(replacer.getKey())) {
+				updatedLine = updatedLine.replaceAll(replacer.getKey(), replacer.getValue().update(player));
+			}
+		}
+
+		return updatedLine;
+	}
+
 	public static void load(Plugin plugin) {
 		
 		Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, new Runnable() {


### PR DESCRIPTION
This PR extends the existing API to include support for player relative placeholders. This works with no modification of the existing API to ensure backwards compatibility.

It works by creating a new type of `PlaceholderReplacer` that provides a reference to the `Player` that is being sent the hologram. The only code that is edited is the code in the old and new `ProtocolLibHookImpl` classes. This means that player relative placeholders just won't work if the user doesn't have ProtocolLib (just like the existing ones).

Basically while making this I aimed to make it not look like a new feature, but rather an extension of the existing player relative placeholders (although the code has a fair few additions!)

To begin with I've just added a `{gamemode}` placeholder but the api is exactly the same as the current one so it won't be hard at all to add more.