### PR TITLE
Add API method to get Hologram from Bukkit Entity

### DIFF
--- a/API/src/main/java/com/gmail/filoghost/holographicdisplays/api/HologramsAPI.java
+++ b/API/src/main/java/com/gmail/filoghost/holographicdisplays/api/HologramsAPI.java
@@ -103,5 +103,16 @@ public class HologramsAPI {
 	public static boolean isHologramEntity(Entity bukkitEntity) {
 		return BackendAPI.getImplementation().isHologramEntity(bukkitEntity);
 	}
+	
+	
+	/**
+	 * Gets the hologram that the entity is part of.
+	 * 
+	 * @param bukkitEntity the entity of the hologram
+	 * @return the hologram that the entity is part of
+	 */
+	public static Hologram getHologram(Entity bukkitEntity) {
+		return BackendAPI.getImplementation().getHologram(bukkitEntity);
+	}
 
 }

--- a/API/src/main/java/com/gmail/filoghost/holographicdisplays/api/internal/BackendAPI.java
+++ b/API/src/main/java/com/gmail/filoghost/holographicdisplays/api/internal/BackendAPI.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.plugin.Plugin;
 
 import com.gmail.filoghost.holographicdisplays.api.Hologram;
+import com.gmail.filoghost.holographicdisplays.api.line.HologramLine;
 import com.gmail.filoghost.holographicdisplays.api.placeholder.PlaceholderReplacer;
 
 public abstract class BackendAPI {
@@ -37,7 +38,14 @@ public abstract class BackendAPI {
 
 	public abstract void unregisterPlaceholders(Plugin plugin);
 
-	public abstract boolean isHologramEntity(Entity bukkitEntity);	
+	public abstract boolean isHologramEntity(Entity bukkitEntity);
+
+	public abstract HologramLine getHologramLine(Entity bukkitEntity);
+
+	public Hologram getHologram(Entity bukkitEntity) {
+		HologramLine line = getHologramLine(bukkitEntity);
+		return line != null ? line.getParent(): null;
+	}
 	
 
 }

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/object/DefaultBackendAPI.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/object/DefaultBackendAPI.java
@@ -10,6 +10,7 @@ import org.bukkit.plugin.Plugin;
 import com.gmail.filoghost.holographicdisplays.HolographicDisplays;
 import com.gmail.filoghost.holographicdisplays.api.Hologram;
 import com.gmail.filoghost.holographicdisplays.api.internal.BackendAPI;
+import com.gmail.filoghost.holographicdisplays.api.line.HologramLine;
 import com.gmail.filoghost.holographicdisplays.api.placeholder.PlaceholderReplacer;
 import com.gmail.filoghost.holographicdisplays.object.PluginHologram;
 import com.gmail.filoghost.holographicdisplays.object.PluginHologramManager;
@@ -42,6 +43,11 @@ public class DefaultBackendAPI extends BackendAPI {
 	public boolean isHologramEntity(Entity bukkitEntity) {
 		Validator.notNull(bukkitEntity, "bukkitEntity");
 		return HolographicDisplays.getNMSManager().isNMSEntityBase(bukkitEntity);
+	}
+
+	public HologramLine getHologramLine(Entity bukkitEntity) {
+		Validator.notNull(bukkitEntity, "bukkitEntity");
+		return HolographicDisplays.getNMSManager().getNMSEntityBase(bukkitEntity).getHologramLine();
 	}
 
 	public Collection<Hologram> getHolograms(Plugin plugin) {


### PR DESCRIPTION
Hi,
as the title says, this PR adds a method to get a Hologram from a Bukkit Entity.

Use-case: I need to exclude some plugins from PlayerInteractEntityEvent if the entity is an HD hologram spawned by my plugin.

See DRE2N/HolographicMenus/issues/15

https://github.com/DRE2N/HolographicMenus/blob/protection-fix/src/main/java/de/erethon/holographicmenus/hologram/HolographicDisplaysWrapper.java#L95