### PR TITLE
added support, that a ItemLine can now have a amount

### DIFF
--- a/NMS/v1_11_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_11_R1/EntityNMSItem.java
+++ b/NMS/v1_11_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_11_R1/EntityNMSItem.java
@@ -197,8 +197,6 @@ public class EntityNMSItem extends EntityItem implements NMSItem {
 		NBTTagList tagList = new NBTTagList();
 		tagList.add(new NBTTagString(ItemUtils.ANTISTACK_LORE)); // Antistack lore
 		display.set("Lore", tagList);
-
-		newItem.setCount(1);
 		
 		setItemStack(newItem);
 	}

--- a/NMS/v1_12_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_12_R1/EntityNMSItem.java
+++ b/NMS/v1_12_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_12_R1/EntityNMSItem.java
@@ -197,8 +197,6 @@ public class EntityNMSItem extends EntityItem implements NMSItem {
 		NBTTagList tagList = new NBTTagList();
 		tagList.add(new NBTTagString(ItemUtils.ANTISTACK_LORE)); // Antistack lore
 		display.set("Lore", tagList);
-
-		newItem.setCount(1);
 		
 		setItemStack(newItem);
 	}

--- a/NMS/v1_13_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R1/EntityNMSItem.java
+++ b/NMS/v1_13_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R1/EntityNMSItem.java
@@ -197,8 +197,6 @@ public class EntityNMSItem extends EntityItem implements NMSItem {
 		NBTTagList tagList = new NBTTagList();
 		tagList.add(new NBTTagString(ItemUtils.ANTISTACK_LORE)); // Antistack lore
 		display.set("Lore", tagList);
-
-		newItem.setCount(1);
 		
 		setItemStack(newItem);
 	}

--- a/NMS/v1_13_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R2/EntityNMSItem.java
+++ b/NMS/v1_13_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R2/EntityNMSItem.java
@@ -197,8 +197,6 @@ public class EntityNMSItem extends EntityItem implements NMSItem {
 		NBTTagList tagList = new NBTTagList();
 		tagList.add(new NBTTagString(ItemUtils.ANTISTACK_LORE)); // Antistack lore
 		display.set("Lore", tagList);
-
-		newItem.setCount(1);
 		
 		setItemStack(newItem);
 	}

--- a/NMS/v1_14_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_14_R1/EntityNMSItem.java
+++ b/NMS/v1_14_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_14_R1/EntityNMSItem.java
@@ -199,8 +199,6 @@ public class EntityNMSItem extends EntityItem implements NMSItem {
 		NBTTagList tagList = new NBTTagList();
 		tagList.add(new NBTTagString(ItemUtils.ANTISTACK_LORE)); // Antistack lore
 		display.set("Lore", tagList);
-
-		newItem.setCount(1);
 		
 		setItemStack(newItem);
 	}


### PR DESCRIPTION
As mentioned in the issue #222, is it not possible to make a hologram with a Item, that has a amount. So with this it is now possible to make a hologram like this: https://cdn.discordapp.com/attachments/520955035832811521/622204749374029824/2019-09-14_00.58.13.png
I don't know, if this is a feature, that HolographicDisplays will have, but i made this change, because i can use this feature, and i can't see, why it should hurt.