### PR TITLE
Added PlaceholderAPI support.

### DIFF
--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -22,10 +22,15 @@
 			<id>dmulloy2-repo</id>
 			<url>http://repo.dmulloy2.net/nexus/repository/public/</url>
 		</repository>
-		
+
 		<repository>
 			<id>codemc-repo</id>
 			<url>https://repo.codemc.org/repository/maven-public/</url>
+		</repository>
+
+		<repository>
+			<id>placeholderapi</id>
+			<url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
 		</repository>
 	</repositories>
 
@@ -41,7 +46,7 @@
 			<artifactId>holographicdisplays-utils</artifactId>
 			<version>2.4.1-SNAPSHOT</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>holographicdisplays-config</artifactId>
@@ -53,67 +58,67 @@
 			<artifactId>holographicdisplays-nms-interfaces</artifactId>
 			<version>2.4.1-SNAPSHOT</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>holographicdisplays-nms-v1_8_r1</artifactId>
 			<version>2.4.1-SNAPSHOT</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>holographicdisplays-nms-v1_8_r2</artifactId>
 			<version>2.4.1-SNAPSHOT</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>holographicdisplays-nms-v1_8_r3</artifactId>
 			<version>2.4.1-SNAPSHOT</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>holographicdisplays-nms-v1_9_r1</artifactId>
 			<version>2.4.1-SNAPSHOT</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>holographicdisplays-nms-v1_9_r2</artifactId>
 			<version>2.4.1-SNAPSHOT</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>holographicdisplays-nms-v1_10_r1</artifactId>
 			<version>2.4.1-SNAPSHOT</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>holographicdisplays-nms-v1_11_r1</artifactId>
 			<version>2.4.1-SNAPSHOT</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>holographicdisplays-nms-v1_12_r1</artifactId>
 			<version>2.4.1-SNAPSHOT</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>holographicdisplays-nms-v1_13_r1</artifactId>
 			<version>2.4.1-SNAPSHOT</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>holographicdisplays-nms-v1_13_r2</artifactId>
 			<version>2.4.1-SNAPSHOT</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>holographicdisplays-nms-v1_14_r1</artifactId>
@@ -145,11 +150,18 @@
 			<artifactId>bstats-bukkit-lite</artifactId>
 			<version>1.5</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>me.filoghost.updatechecker</groupId>
 			<artifactId>updatechecker</artifactId>
 			<version>1.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>me.clip</groupId>
+			<artifactId>placeholderapi</artifactId>
+			<version>2.0.6</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/HolographicDisplays.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/HolographicDisplays.java
@@ -3,26 +3,16 @@
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
  *  (at your option) any later version.
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License
  *  along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package com.gmail.filoghost.holographicdisplays;
-
-import java.io.File;
-import java.util.logging.Level;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.bstats.bukkit.MetricsLite;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import com.gmail.filoghost.holographicdisplays.api.internal.BackendAPI;
 import com.gmail.filoghost.holographicdisplays.bridge.bungeecord.BungeeServerTracker;
@@ -31,13 +21,10 @@ import com.gmail.filoghost.holographicdisplays.commands.main.HologramsCommandHan
 import com.gmail.filoghost.holographicdisplays.disk.Configuration;
 import com.gmail.filoghost.holographicdisplays.disk.HologramDatabase;
 import com.gmail.filoghost.holographicdisplays.disk.UnicodeSymbols;
+import com.gmail.filoghost.holographicdisplays.hook.PlaceholderAPIHook;
 import com.gmail.filoghost.holographicdisplays.listener.MainListener;
 import com.gmail.filoghost.holographicdisplays.nms.interfaces.NMSManager;
-import com.gmail.filoghost.holographicdisplays.object.DefaultBackendAPI;
-import com.gmail.filoghost.holographicdisplays.object.NamedHologram;
-import com.gmail.filoghost.holographicdisplays.object.NamedHologramManager;
-import com.gmail.filoghost.holographicdisplays.object.PluginHologram;
-import com.gmail.filoghost.holographicdisplays.object.PluginHologramManager;
+import com.gmail.filoghost.holographicdisplays.object.*;
 import com.gmail.filoghost.holographicdisplays.placeholder.AnimationsRegister;
 import com.gmail.filoghost.holographicdisplays.placeholder.PlaceholdersManager;
 import com.gmail.filoghost.holographicdisplays.task.BungeeCleanupTask;
@@ -46,234 +33,246 @@ import com.gmail.filoghost.holographicdisplays.task.WorldPlayerCounterTask;
 import com.gmail.filoghost.holographicdisplays.util.ConsoleLogger;
 import com.gmail.filoghost.holographicdisplays.util.NMSVersion;
 import com.gmail.filoghost.holographicdisplays.util.VersionUtils;
-
 import me.filoghost.updatechecker.UpdateChecker;
+import org.bstats.bukkit.MetricsLite;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class HolographicDisplays extends JavaPlugin {
-	
-	// The main instance of the plugin.
-	private static HolographicDisplays instance;
-	
-	// The manager for net.minecraft.server access.
-	private static NMSManager nmsManager;
-	
-	// The listener for all the Bukkit and NMS events.
-	private static MainListener mainListener;
-	
-	// The command handler, just in case a plugin wants to register more commands.
-	private static HologramsCommandHandler commandHandler;
-	
-	// The new version found by the updater, null if there is no new version.
-	private static String newVersion;
-	
-	// Not null if ProtocolLib is installed and successfully loaded.
-	private static ProtocolLibHook protocolLibHook;
-	
-	@Override
-	public void onEnable() {
-		
-		// Warn about plugin reloaders and the /reload command.
-		if (instance != null || System.getProperty("HolographicDisplaysLoaded") != null) {
-			Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[HolographicDisplays] Please do not use /reload or plugin reloaders. Use the command \"/holograms reload\" instead. You will receive no support for doing this operation.");
-		}
-		
-		System.setProperty("HolographicDisplaysLoaded", "true");
-		instance = this;
-		ConsoleLogger.setLogger(instance.getLogger());
-		
-		// Load placeholders.yml.
-		UnicodeSymbols.load(this);
 
-		// Load the configuration.
-		Configuration.load(this);
-		
-		if (Configuration.updateNotification) {
-			UpdateChecker.run(this, 75097, (String newVersion) -> {
-				HolographicDisplays.newVersion = newVersion;
-				ConsoleLogger.log(Level.INFO, "Found a new version available: " + newVersion);
-				ConsoleLogger.log(Level.INFO, "Download it on Bukkit Dev:");
-				ConsoleLogger.log(Level.INFO, "dev.bukkit.org/projects/holographic-displays");
-			});
-		}
-		
-		if (!NMSVersion.isValid()) {
-			printWarnAndDisable(
-				"******************************************************",
-				"     This version of HolographicDisplays only",
-				"     works on server versions from 1.8 to 1.15.",
-				"     The plugin will be disabled.",
-				"******************************************************"
-			);
-			return;
-		}
-		
-		try {
-			nmsManager = (NMSManager) Class.forName("com.gmail.filoghost.holographicdisplays.nms." + NMSVersion.getCurrent() + ".NmsManagerImpl").getConstructor().newInstance();
-		} catch (Throwable t) {
-			t.printStackTrace();
-			printWarnAndDisable(
-				"******************************************************",
-				"     HolographicDisplays was unable to instantiate",
-				"     the NMS manager. The plugin will be disabled.",
-				"******************************************************"
-			);
-			return;
-		}
+    // The main instance of the plugin.
+    private static HolographicDisplays instance;
 
-		try {
-			nmsManager.setup();
-		} catch (Exception e) {
-			e.printStackTrace();
-			printWarnAndDisable(
-				"******************************************************",
-				"     HolographicDisplays was unable to register",
-				"     custom entities, the plugin will be disabled.",
-				"     Are you using the correct Bukkit/Spigot version?",
-				"******************************************************"
-			);
-			return;
-		}
-		
-		// ProtocolLib check.
-		hookProtocolLib();
-		
-		// Load animation files and the placeholder manager.
-		PlaceholdersManager.load(this);
-		try {
-			AnimationsRegister.loadAnimations(this);
-		} catch (Exception ex) {
-			ConsoleLogger.log(Level.WARNING, "Failed to load animation files!", ex);
-		}
-		
-		// Initalize other static classes.
-		HologramDatabase.loadYamlFile(this);
-		BungeeServerTracker.startTask(Configuration.bungeeRefreshSeconds);
-		
-		// Start repeating tasks.
-		Bukkit.getScheduler().scheduleSyncRepeatingTask(this, new BungeeCleanupTask(), 5 * 60 * 20, 5 * 60 * 20);
-		Bukkit.getScheduler().scheduleSyncRepeatingTask(this, new WorldPlayerCounterTask(), 0L, 3 * 20);
-		
-		if (getCommand("holograms") == null) {
-			printWarnAndDisable(
-				"******************************************************",
-				"     HolographicDisplays was unable to register",
-				"     the command \"holograms\". Do not modify",
-				"     plugin.yml removing commands, if this is",
-				"     the case.",
-				"******************************************************"
-			);
-			return;
-		}
-		
-		getCommand("holograms").setExecutor(commandHandler = new HologramsCommandHandler());
-		Bukkit.getPluginManager().registerEvents(mainListener = new MainListener(nmsManager), this);
+    // The manager for net.minecraft.server access.
+    private static NMSManager nmsManager;
 
-		// Register bStats metrics
-		new MetricsLite(this);
-		
-		// Holograms are loaded later, when the worlds are ready.
-		Bukkit.getScheduler().runTask(this, new StartupLoadHologramsTask());
-		
-		// Enable the API.
-		BackendAPI.setImplementation(new DefaultBackendAPI());
-	}
-	
+    // The listener for all the Bukkit and NMS events.
+    private static MainListener mainListener;
 
-	@Override
-	public void onDisable() {
-		for (NamedHologram hologram : NamedHologramManager.getHolograms()) {
-			hologram.despawnEntities();
-		}
-		for (PluginHologram hologram : PluginHologramManager.getHolograms()) {
-			hologram.despawnEntities();
-		}
-	}
-	
-	public static NMSManager getNMSManager() {
-		return nmsManager;
-	}
-	
-	public static MainListener getMainListener() {
-		return mainListener;
-	}
+    // The command handler, just in case a plugin wants to register more commands.
+    private static HologramsCommandHandler commandHandler;
 
-	public static HologramsCommandHandler getCommandHandler() {
-		return commandHandler;
-	}
-	
-	private static void printWarnAndDisable(String... messages) {
-		StringBuffer buffer = new StringBuffer("\n ");
-		for (String message : messages) {
-			buffer.append('\n');
-			buffer.append(message);
-		}
-		buffer.append('\n');
-		System.out.println(buffer.toString());
-		try {
-			Thread.sleep(5000);
-		} catch (InterruptedException ex) { }
-		instance.setEnabled(false);
-	}
+    // The new version found by the updater, null if there is no new version.
+    private static String newVersion;
 
-	public static HolographicDisplays getInstance() {
-		return instance;
-	}
+    // Not null if ProtocolLib is installed and successfully loaded.
+    private static ProtocolLibHook protocolLibHook;
+
+    @Override
+    public void onEnable() {
+
+        // Warn about plugin reloaders and the /reload command.
+        if (instance != null || System.getProperty("HolographicDisplaysLoaded") != null) {
+            Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[HolographicDisplays] Please do not use /reload or plugin reloaders. Use the command \"/holograms reload\" instead. You will receive no support for doing this operation.");
+        }
+
+        System.setProperty("HolographicDisplaysLoaded", "true");
+        instance = this;
+        ConsoleLogger.setLogger(instance.getLogger());
+
+        // Load placeholders.yml.
+        UnicodeSymbols.load(this);
+
+        // Load the configuration.
+        Configuration.load(this);
+
+        if (Configuration.updateNotification) {
+            UpdateChecker.run(this, 75097, (String newVersion) -> {
+                HolographicDisplays.newVersion = newVersion;
+                ConsoleLogger.log(Level.INFO, "Found a new version available: " + newVersion);
+                ConsoleLogger.log(Level.INFO, "Download it on Bukkit Dev:");
+                ConsoleLogger.log(Level.INFO, "dev.bukkit.org/projects/holographic-displays");
+            });
+        }
+
+        if (!NMSVersion.isValid()) {
+            printWarnAndDisable(
+                    "******************************************************",
+                    "     This version of HolographicDisplays only",
+                    "     works on server versions from 1.8 to 1.15.",
+                    "     The plugin will be disabled.",
+                    "******************************************************"
+            );
+            return;
+        }
+
+        try {
+            nmsManager = (NMSManager) Class.forName("com.gmail.filoghost.holographicdisplays.nms." + NMSVersion.getCurrent() + ".NmsManagerImpl").getConstructor().newInstance();
+        } catch (Throwable t) {
+            t.printStackTrace();
+            printWarnAndDisable(
+                    "******************************************************",
+                    "     HolographicDisplays was unable to instantiate",
+                    "     the NMS manager. The plugin will be disabled.",
+                    "******************************************************"
+            );
+            return;
+        }
+
+        try {
+            nmsManager.setup();
+        } catch (Exception e) {
+            e.printStackTrace();
+            printWarnAndDisable(
+                    "******************************************************",
+                    "     HolographicDisplays was unable to register",
+                    "     custom entities, the plugin will be disabled.",
+                    "     Are you using the correct Bukkit/Spigot version?",
+                    "******************************************************"
+            );
+            return;
+        }
+
+        // ProtocolLib check.
+        hookProtocolLib();
+
+        // Load animation files and the placeholder manager.
+        PlaceholdersManager.load(this);
+        try {
+            AnimationsRegister.loadAnimations(this);
+        } catch (Exception ex) {
+            ConsoleLogger.log(Level.WARNING, "Failed to load animation files!", ex);
+        }
+
+        // Initalize other static classes.
+        HologramDatabase.loadYamlFile(this);
+        BungeeServerTracker.startTask(Configuration.bungeeRefreshSeconds);
+
+        // Start repeating tasks.
+        Bukkit.getScheduler().scheduleSyncRepeatingTask(this, new BungeeCleanupTask(), 5 * 60 * 20, 5 * 60 * 20);
+        Bukkit.getScheduler().scheduleSyncRepeatingTask(this, new WorldPlayerCounterTask(), 0L, 3 * 20);
+
+        if (getCommand("holograms") == null) {
+            printWarnAndDisable(
+                    "******************************************************",
+                    "     HolographicDisplays was unable to register",
+                    "     the command \"holograms\". Do not modify",
+                    "     plugin.yml removing commands, if this is",
+                    "     the case.",
+                    "******************************************************"
+            );
+            return;
+        }
+
+        getCommand("holograms").setExecutor(commandHandler = new HologramsCommandHandler());
+        Bukkit.getPluginManager().registerEvents(mainListener = new MainListener(nmsManager), this);
+
+        // Register bStats metrics
+        new MetricsLite(this);
+
+        // Hook into PlaceholderAPI.
+        new PlaceholderAPIHook();
+
+        // Holograms are loaded later, when the worlds are ready.
+        Bukkit.getScheduler().runTask(this, new StartupLoadHologramsTask());
+
+        // Enable the API.
+        BackendAPI.setImplementation(new DefaultBackendAPI());
+    }
 
 
-	public static String getNewVersion() {
-		return newVersion;
-	}
-	
-	
-	public void hookProtocolLib() {
-		if (!Bukkit.getPluginManager().isPluginEnabled("ProtocolLib")) {
-			return;
-		}
+    @Override
+    public void onDisable() {
+        for (NamedHologram hologram : NamedHologramManager.getHolograms()) {
+            hologram.despawnEntities();
+        }
+        for (PluginHologram hologram : PluginHologramManager.getHolograms()) {
+            hologram.despawnEntities();
+        }
+    }
 
-		try {
-			String protocolVersion = Bukkit.getPluginManager().getPlugin("ProtocolLib").getDescription().getVersion();
-			Matcher versionNumbersMatcher = Pattern.compile("([0-9\\.])+").matcher(protocolVersion);
-			
-			if (!versionNumbersMatcher.find()) {
-				throw new IllegalArgumentException("could not find version numbers pattern");
-			}
-			
-			String versionNumbers = versionNumbersMatcher.group();
-			
-			if (!VersionUtils.isVersionGreaterEqual(versionNumbers, "4.1")) {
-				Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[Holographic Displays] Detected old version of ProtocolLib, support disabled. You must use ProtocolLib 4.1 or higher.");
-				return;
-			}
-			
-		} catch (Exception e) {
-			ConsoleLogger.log(Level.WARNING, "Could not detect ProtocolLib version (" + e.getClass().getName() + ": " + e.getMessage() + "), enabling support anyway and hoping for the best. If you get errors, please contact the author.");
-		}
-		
-		try {
-			ProtocolLibHook protocolLibHook = new com.gmail.filoghost.holographicdisplays.bridge.protocollib.current.ProtocolLibHookImpl();
-			
-			if (protocolLibHook.hook(this, nmsManager)) {
-				HolographicDisplays.protocolLibHook = protocolLibHook;
-				ConsoleLogger.log(Level.INFO, "Enabled player relative placeholders with ProtocolLib.");
-			}
-		} catch (Exception e) {
-			ConsoleLogger.log(Level.WARNING, "Failed to load ProtocolLib support. Is it updated?", e);
-		}
-	}
-	
-	
-	public static boolean hasProtocolLibHook() {
-		return protocolLibHook != null;
-	}
-	
-	
-	public static ProtocolLibHook getProtocolLibHook() {
-		return protocolLibHook;
-	}
-	
-	
-	public static boolean isConfigFile(File file) {
-		return file.getName().toLowerCase().endsWith(".yml") && instance.getResource(file.getName()) != null;
-	}
-	
+    public static NMSManager getNMSManager() {
+        return nmsManager;
+    }
+
+    public static MainListener getMainListener() {
+        return mainListener;
+    }
+
+    public static HologramsCommandHandler getCommandHandler() {
+        return commandHandler;
+    }
+
+    private static void printWarnAndDisable(String... messages) {
+        StringBuffer buffer = new StringBuffer("\n ");
+        for (String message : messages) {
+            buffer.append('\n');
+            buffer.append(message);
+        }
+        buffer.append('\n');
+        System.out.println(buffer.toString());
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException ex) {
+        }
+        instance.setEnabled(false);
+    }
+
+    public static HolographicDisplays getInstance() {
+        return instance;
+    }
+
+
+    public static String getNewVersion() {
+        return newVersion;
+    }
+
+
+    public void hookProtocolLib() {
+        if (!Bukkit.getPluginManager().isPluginEnabled("ProtocolLib")) {
+            return;
+        }
+
+        try {
+            String protocolVersion = Bukkit.getPluginManager().getPlugin("ProtocolLib").getDescription().getVersion();
+            Matcher versionNumbersMatcher = Pattern.compile("([0-9\\.])+").matcher(protocolVersion);
+
+            if (!versionNumbersMatcher.find()) {
+                throw new IllegalArgumentException("could not find version numbers pattern");
+            }
+
+            String versionNumbers = versionNumbersMatcher.group();
+
+            if (!VersionUtils.isVersionGreaterEqual(versionNumbers, "4.1")) {
+                Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[Holographic Displays] Detected old version of ProtocolLib, support disabled. You must use ProtocolLib 4.1 or higher.");
+                return;
+            }
+
+        } catch (Exception e) {
+            ConsoleLogger.log(Level.WARNING, "Could not detect ProtocolLib version (" + e.getClass().getName() + ": " + e.getMessage() + "), enabling support anyway and hoping for the best. If you get errors, please contact the author.");
+        }
+
+        try {
+            ProtocolLibHook protocolLibHook = new com.gmail.filoghost.holographicdisplays.bridge.protocollib.current.ProtocolLibHookImpl();
+
+            if (protocolLibHook.hook(this, nmsManager)) {
+                HolographicDisplays.protocolLibHook = protocolLibHook;
+                ConsoleLogger.log(Level.INFO, "Enabled player relative placeholders with ProtocolLib.");
+            }
+        } catch (Exception e) {
+            ConsoleLogger.log(Level.WARNING, "Failed to load ProtocolLib support. Is it updated?", e);
+        }
+    }
+
+
+    public static boolean hasProtocolLibHook() {
+        return protocolLibHook != null;
+    }
+
+
+    public static ProtocolLibHook getProtocolLibHook() {
+        return protocolLibHook;
+    }
+
+
+    public static boolean isConfigFile(File file) {
+        return file.getName().toLowerCase().endsWith(".yml") && instance.getResource(file.getName()) != null;
+    }
+
 }

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/bridge/protocollib/current/ProtocolLibHookImpl.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/bridge/protocollib/current/ProtocolLibHookImpl.java
@@ -3,24 +3,16 @@
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
  *  (at your option) any later version.
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License
  *  along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package com.gmail.filoghost.holographicdisplays.bridge.protocollib.current;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
 
 import com.comphenix.net.sf.cglib.proxy.Factory;
 import com.comphenix.protocol.PacketType;
@@ -37,28 +29,33 @@ import com.gmail.filoghost.holographicdisplays.bridge.protocollib.current.packet
 import com.gmail.filoghost.holographicdisplays.bridge.protocollib.current.packet.WrapperPlayServerEntityMetadata;
 import com.gmail.filoghost.holographicdisplays.bridge.protocollib.current.packet.WrapperPlayServerSpawnEntity;
 import com.gmail.filoghost.holographicdisplays.bridge.protocollib.current.packet.WrapperPlayServerSpawnEntityLiving;
+import com.gmail.filoghost.holographicdisplays.hook.PlaceholderAPIHook;
 import com.gmail.filoghost.holographicdisplays.nms.interfaces.NMSManager;
 import com.gmail.filoghost.holographicdisplays.nms.interfaces.entity.NMSArmorStand;
 import com.gmail.filoghost.holographicdisplays.nms.interfaces.entity.NMSEntityBase;
 import com.gmail.filoghost.holographicdisplays.object.CraftHologram;
-import com.gmail.filoghost.holographicdisplays.object.line.CraftHologramLine;
-import com.gmail.filoghost.holographicdisplays.object.line.CraftItemLine;
-import com.gmail.filoghost.holographicdisplays.object.line.CraftTextLine;
-import com.gmail.filoghost.holographicdisplays.object.line.CraftTouchSlimeLine;
-import com.gmail.filoghost.holographicdisplays.object.line.CraftTouchableLine;
+import com.gmail.filoghost.holographicdisplays.object.line.*;
 import com.gmail.filoghost.holographicdisplays.placeholder.RelativePlaceholder;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * This is for the ProtocolLib versions containing the WrappedDataWatcher.WrappedDataWatcherObject class.
  */
 public class ProtocolLibHookImpl implements ProtocolLibHook {
-	
+
 	private NMSManager nmsManager;
 	private PacketHelper packetHelper;
 	private MetadataHelper metadataHelper;
 	private boolean useGetEntityWorkaround;
-	
-	
+
+
 	@Override
 	public boolean hook(Plugin plugin, NMSManager nmsManager) {
 		this.nmsManager = nmsManager;
@@ -66,110 +63,114 @@ public class ProtocolLibHookImpl implements ProtocolLibHook {
 		this.packetHelper = new PacketHelper(metadataHelper);
 
 		AdapterParameteters params = PacketAdapter
-			.params()
-			.plugin(plugin)
-			.types(
-				PacketType.Play.Server.SPAWN_ENTITY_LIVING,
-				PacketType.Play.Server.SPAWN_ENTITY,
-				PacketType.Play.Server.ENTITY_METADATA)
-			.serverSide()
-			.listenerPriority(ListenerPriority.NORMAL);
-		
+				.params()
+				.plugin(plugin)
+				.types(
+						PacketType.Play.Server.SPAWN_ENTITY_LIVING,
+						PacketType.Play.Server.SPAWN_ENTITY,
+						PacketType.Play.Server.ENTITY_METADATA)
+				.serverSide()
+				.listenerPriority(ListenerPriority.NORMAL);
+
 		ProtocolLibrary.getProtocolManager().addPacketListener(new PacketAdapter(params) {
-					  
-				@Override
-				public void onPacketSending(PacketEvent event) {
-					
-					PacketContainer packet = event.getPacket();
-					Player player = event.getPlayer();
-					
-					if (player instanceof Factory) {
-						return; // Ignore temporary players (reference: https://github.com/dmulloy2/ProtocolLib/issues/349)
+
+			@Override
+			public void onPacketSending(PacketEvent event) {
+
+				PacketContainer packet = event.getPacket();
+				Player player = event.getPlayer();
+
+				if (player instanceof Factory) {
+					return; // Ignore temporary players (reference: https://github.com/dmulloy2/ProtocolLib/issues/349)
+				}
+
+				// Spawn entity packet
+				if (packet.getType() == PacketType.Play.Server.SPAWN_ENTITY_LIVING) {
+
+					WrapperPlayServerSpawnEntityLiving spawnEntityPacket = new WrapperPlayServerSpawnEntityLiving(packet);
+					Entity entity = getEntity(event, spawnEntityPacket);
+
+					CraftHologramLine hologramLine = getHologramLine(entity);
+					if (hologramLine == null) {
+						return;
 					}
 
-					// Spawn entity packet
-					if (packet.getType() == PacketType.Play.Server.SPAWN_ENTITY_LIVING) {
+					if (!hologramLine.getParent().getVisibilityManager().isVisibleTo(player)) {
+						event.setCancelled(true);
+						return;
+					}
 
-						WrapperPlayServerSpawnEntityLiving spawnEntityPacket = new WrapperPlayServerSpawnEntityLiving(packet);
-						Entity entity = getEntity(event, spawnEntityPacket);
-						
-						CraftHologramLine hologramLine = getHologramLine(entity);
-						if (hologramLine == null) {
-							return;
-						}
-						
-						if (!hologramLine.getParent().getVisibilityManager().isVisibleTo(player)) {
-							event.setCancelled(true);
-							return;
-						}
-						
-						if (!hologramLine.getParent().isAllowPlaceholders() || !hologramLine.hasRelativePlaceholders()) {
-							return;
-						}
-						
-						spawnEntityPacket = new WrapperPlayServerSpawnEntityLiving(packet.deepClone());
-						WrappedWatchableObject customNameWatchableObject = metadataHelper.getCustomNameWacthableObject(spawnEntityPacket.getMetadata());
-						
-						if (customNameWatchableObject == null) {
-							return;
-						}
-						
-						replaceRelativePlaceholders(customNameWatchableObject, player, hologramLine.getRelativePlaceholders());
+					if (!hologramLine.getParent().isAllowPlaceholders()) {
+						return;
+					}
+
+					spawnEntityPacket = new WrapperPlayServerSpawnEntityLiving(packet.deepClone());
+					WrappedWatchableObject customNameWatchableObject = metadataHelper.getCustomNameWacthableObject(spawnEntityPacket.getMetadata());
+
+					if (customNameWatchableObject == null) {
+						return;
+					}
+
+					boolean modifiedRelative = replaceRelativePlaceholders(customNameWatchableObject, player, hologramLine.getRelativePlaceholders());
+					boolean modifiedPapi = replacePlaceholderAPI(customNameWatchableObject, player);
+					if (modifiedRelative || modifiedPapi) {
 						event.setPacket(spawnEntityPacket.getHandle());
+					}
 
-					} else if (packet.getType() == PacketType.Play.Server.SPAWN_ENTITY) {
+				} else if (packet.getType() == PacketType.Play.Server.SPAWN_ENTITY) {
 
-						WrapperPlayServerSpawnEntity spawnEntityPacket = new WrapperPlayServerSpawnEntity(packet);
-						Entity entity = getEntity(event, spawnEntityPacket);
-						
-						CraftHologramLine hologramLine = getHologramLine(entity);
-						if (hologramLine == null) {
-							return;
-						}
-						
-						if (!hologramLine.getParent().getVisibilityManager().isVisibleTo(player)) {
-							event.setCancelled(true);
-							return;
-						}
-					
-					} else if (packet.getType() == PacketType.Play.Server.ENTITY_METADATA) {
+					WrapperPlayServerSpawnEntity spawnEntityPacket = new WrapperPlayServerSpawnEntity(packet);
+					Entity entity = getEntity(event, spawnEntityPacket);
 
-						WrapperPlayServerEntityMetadata entityMetadataPacket = new WrapperPlayServerEntityMetadata(packet);
-						Entity entity = getEntity(event, entityMetadataPacket);
-						
-						CraftHologramLine hologramLine = getHologramLine(entity);
-						if (hologramLine == null) {
-							return;
-						}
-						
-						if (!hologramLine.getParent().getVisibilityManager().isVisibleTo(player)) {
-							event.setCancelled(true);
-							return;
-						}
-						
-						if (!hologramLine.getParent().isAllowPlaceholders() || !hologramLine.hasRelativePlaceholders()) {
-							return;
-						}
-						
-						entityMetadataPacket = new WrapperPlayServerEntityMetadata(packet.deepClone());
-						WrappedWatchableObject customNameWatchableObject = metadataHelper.getCustomNameWatchableObject(entityMetadataPacket.getEntityMetadata());
-						
-						if (customNameWatchableObject == null) {
-							return;
-						}
-						
-						boolean modified = replaceRelativePlaceholders(customNameWatchableObject, player, hologramLine.getRelativePlaceholders());
-						if (modified) {
-							event.setPacket(entityMetadataPacket.getHandle());
-						}
+					CraftHologramLine hologramLine = getHologramLine(entity);
+					if (hologramLine == null) {
+						return;
+					}
+
+					if (!hologramLine.getParent().getVisibilityManager().isVisibleTo(player)) {
+						event.setCancelled(true);
+						return;
+					}
+
+				} else if (packet.getType() == PacketType.Play.Server.ENTITY_METADATA) {
+
+					WrapperPlayServerEntityMetadata entityMetadataPacket = new WrapperPlayServerEntityMetadata(packet);
+					Entity entity = getEntity(event, entityMetadataPacket);
+
+					CraftHologramLine hologramLine = getHologramLine(entity);
+					if (hologramLine == null) {
+						return;
+					}
+
+					if (!hologramLine.getParent().getVisibilityManager().isVisibleTo(player)) {
+						event.setCancelled(true);
+						return;
+					}
+
+					if (!hologramLine.getParent().isAllowPlaceholders()) {
+						return;
+					}
+
+					entityMetadataPacket = new WrapperPlayServerEntityMetadata(packet.deepClone());
+					WrappedWatchableObject customNameWatchableObject = metadataHelper.getCustomNameWatchableObject(entityMetadataPacket.getEntityMetadata());
+
+					if (customNameWatchableObject == null) {
+						return;
+					}
+
+					boolean modifiedRelative = replaceRelativePlaceholders(customNameWatchableObject, player, hologramLine.getRelativePlaceholders());
+					boolean modifiedPapi = replacePlaceholderAPI(customNameWatchableObject, player);
+					if (modifiedRelative || modifiedPapi) {
+						event.setPacket(entityMetadataPacket.getHandle());
 					}
 				}
-			});
-		
+			}
+		});
+
 		return true;
 	}
-	
-	
+
+
 	private Entity getEntity(PacketEvent packetEvent, EntityRelatedPacketWrapper packetWrapper) {
 		if (!useGetEntityWorkaround) {
 			try {
@@ -178,31 +179,49 @@ public class ProtocolLibHookImpl implements ProtocolLibHook {
 				useGetEntityWorkaround = true;
 			}
 		}
-		
+
 		// Use workaround, get entity from its ID through NMS
 		return HolographicDisplays.getNMSManager().getEntityFromID(packetEvent.getPlayer().getWorld(), packetWrapper.getEntityID());
 	}
-	
-	
+
+
 	private boolean replaceRelativePlaceholders(WrappedWatchableObject customNameWatchableObject, Player player, Collection<RelativePlaceholder> relativePlaceholders) {
 		if (customNameWatchableObject == null) {
 			return true;
 		}
-		
+
 		String customName = metadataHelper.getSerializedCustomName(customNameWatchableObject);
 		if (customName == null) {
 			return false;
 		}
-		
+
+		if (relativePlaceholders == null) return false;
+
 		for (RelativePlaceholder relativePlaceholder : relativePlaceholders) {
 			customName = customName.replace(relativePlaceholder.getTextPlaceholder(), relativePlaceholder.getReplacement(player));
 		}
-		
+
 		metadataHelper.setSerializedCustomName(customNameWatchableObject, customName);
 		return true;
 	}
-	
-	
+
+	private boolean replacePlaceholderAPI(WrappedWatchableObject customNameWatchableObject, Player player) {
+		if (customNameWatchableObject == null) {
+			return true;
+		}
+
+		String customName = metadataHelper.getSerializedCustomName(customNameWatchableObject);
+		if (customName == null) {
+			return false;
+		}
+
+		customName = PlaceholderAPIHook.translate(player, customName);
+
+		metadataHelper.setSerializedCustomName(customNameWatchableObject, customName);
+		return true;
+	}
+
+
 	@Override
 	public void sendDestroyEntitiesPacket(Player player, CraftHologram hologram) {
 		List<Integer> ids = new ArrayList<>();
@@ -213,58 +232,58 @@ public class ProtocolLibHookImpl implements ProtocolLibHook {
 				}
 			}
 		}
-		
+
 		if (!ids.isEmpty()) {
 			packetHelper.sendDestroyEntitiesPacket(player, ids);
 		}
 	}
-	
-	
+
+
 	@Override
 	public void sendDestroyEntitiesPacket(Player player, CraftHologramLine line) {
 		if (!line.isSpawned()) {
 			return;
 		}
-		
+
 		List<Integer> ids = new ArrayList<>();
 		for (int id : line.getEntitiesIDs()) {
 			ids.add(id);
 		}
-		
+
 		if (!ids.isEmpty()) {
 			packetHelper.sendDestroyEntitiesPacket(player, ids);
 		}
 	}
-	
-	
+
+
 	@Override
 	public void sendCreateEntitiesPacket(Player player, CraftHologram hologram) {
 		for (CraftHologramLine line : hologram.getLinesUnsafe()) {
 			sendCreateEntitiesPacket(player, line);
 		}
 	}
-	
-	
+
+
 	@Override
 	public void sendCreateEntitiesPacket(Player player, CraftHologramLine line) {
 		if (!line.isSpawned()) {
 			return;
 		}
-		
+
 		CraftTouchableLine touchableLine;
-		
+
 		if (line instanceof CraftTextLine) {
 			CraftTextLine textLine = (CraftTextLine) line;
 			touchableLine = textLine;
-			
+
 			if (textLine.isSpawned()) {
 				packetHelper.sendSpawnArmorStandPacket(player, (NMSArmorStand) textLine.getNmsNameable());
 			}
-			
+
 		} else if (line instanceof CraftItemLine) {
 			CraftItemLine itemLine = (CraftItemLine) line;
 			touchableLine = itemLine;
-			
+
 			if (itemLine.isSpawned()) {
 				packetHelper.sendSpawnArmorStandPacket(player, (NMSArmorStand) itemLine.getNmsVehicle());
 				packetHelper.sendSpawnItemPacket(player, itemLine.getNmsItem());
@@ -274,31 +293,31 @@ public class ProtocolLibHookImpl implements ProtocolLibHook {
 		} else {
 			throw new IllegalArgumentException("Unexpected hologram line type: " + line.getClass().getName());
 		}
-		
+
 		if (touchableLine != null && touchableLine.isSpawned() && touchableLine.getTouchSlime() != null) {
 			CraftTouchSlimeLine touchSlime = touchableLine.getTouchSlime();
-			
+
 			if (touchSlime.isSpawned()) {
 				packetHelper.sendSpawnArmorStandPacket(player, (NMSArmorStand) touchSlime.getNmsVehicle());
-				packetHelper.sendSpawnSlimePacket(player, touchSlime.getNmsSlime());				
+				packetHelper.sendSpawnSlimePacket(player, touchSlime.getNmsSlime());
 				packetHelper.sendVehicleAttachPacket(player, touchSlime.getNmsVehicle(), touchSlime.getNmsSlime());
 			}
 		}
 	}
-	
-	
+
+
 	private CraftHologramLine getHologramLine(Entity bukkitEntity) {
-		if (bukkitEntity != null && isHologramType(bukkitEntity.getType())) {		
+		if (bukkitEntity != null && isHologramType(bukkitEntity.getType())) {
 			NMSEntityBase entity = nmsManager.getNMSEntityBase(bukkitEntity);
 			if (entity != null) {
 				return (CraftHologramLine) entity.getHologramLine();
 			}
 		}
-		
+
 		return null;
 	}
-	
-	
+
+
 	private boolean isHologramType(EntityType type) {
 		return type == EntityType.ARMOR_STAND || type == EntityType.DROPPED_ITEM || type == EntityType.SLIME;
 	}

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/hook/PlaceholderAPIHook.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/hook/PlaceholderAPIHook.java
@@ -1,0 +1,18 @@
+package com.gmail.filoghost.holographicdisplays.hook;
+
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+public class PlaceholderAPIHook {
+    private static boolean enabled;
+
+    public PlaceholderAPIHook() {
+        enabled = Bukkit.getServer().getPluginManager().isPluginEnabled("PlaceholderAPI");
+    }
+
+    public static String translate(Player player, String str) {
+        if (player == null || !enabled) return str;
+        return PlaceholderAPI.setPlaceholders(player, str);
+    }
+}


### PR DESCRIPTION
This PR adds PlaceholderAPI support with the only requirement being PlaceholderAPI and ProtocolLib.

A lot of server owners rely on this plugin for showing their plugin stats across other plugins, and having native support for this will certainly be a huge addition to others. Currently owners are required to use external plugins to do so, so this change will certainly benefit those.

Thanks.