### PR TITLE
Support new 1.16 color codes

### DIFF
--- a/API/pom.xml
+++ b/API/pom.xml
@@ -24,6 +24,11 @@
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>net.md-5</groupId>
+			<artifactId>bungeecord-chat</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/Config/pom.xml
+++ b/Config/pom.xml
@@ -29,6 +29,11 @@
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>net.md-5</groupId>
+			<artifactId>bungeecord-chat</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/Config/src/main/java/com/gmail/filoghost/holographicdisplays/disk/Configuration.java
+++ b/Config/src/main/java/com/gmail/filoghost/holographicdisplays/disk/Configuration.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.logging.Level;
 
+import com.gmail.filoghost.holographicdisplays.util.Utils;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -187,15 +188,10 @@ public class Configuration {
 		
 		ConsoleLogger.setDebugEnabled(config.getBoolean(ConfigNode.DEBUG.getPath()));
 		
-		String tempColor = config.getString(ConfigNode.TRANSPARENCY_COLOR.getPath()).replace('&', ChatColor.COLOR_CHAR);
-		boolean foundColor = false;
-		for (ChatColor chatColor : ChatColor.values()) {
-			if (chatColor.toString().equals(tempColor)) {
-				Configuration.transparencyColor = chatColor;
-				foundColor = true;
-			}
-		}
-		if (!foundColor) {
+		String configTransparencyColor = ChatColor.translateAlternateColorCodes('&', config.getString(ConfigNode.TRANSPARENCY_COLOR.getPath()));
+		if (Utils.isColorCode(configTransparencyColor)) {
+			Configuration.transparencyColor = Utils.toChatColor(configTransparencyColor);
+		} else {
 			Configuration.transparencyColor = ChatColor.GRAY;
 			ConsoleLogger.log(Level.WARNING, "You didn't set a valid chat color for transparency in the configuration, light gray (&7) will be used.");
 		}

--- a/Config/src/main/java/com/gmail/filoghost/holographicdisplays/disk/Configuration.java
+++ b/Config/src/main/java/com/gmail/filoghost/holographicdisplays/disk/Configuration.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.logging.Level;
 
-import org.bukkit.ChatColor;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;

--- a/Config/src/main/java/com/gmail/filoghost/holographicdisplays/disk/StringConverter.java
+++ b/Config/src/main/java/com/gmail/filoghost/holographicdisplays/disk/StringConverter.java
@@ -14,7 +14,7 @@
  */
 package com.gmail.filoghost.holographicdisplays.disk;
 
-import org.bukkit.ChatColor;
+import net.md_5.bungee.api.ChatColor;
 
 public class StringConverter {
 	

--- a/Example/DeathHolograms/src/main/java/com/gmail/filoghost/example/deathholograms/DeathHolograms.java
+++ b/Example/DeathHolograms/src/main/java/com/gmail/filoghost/example/deathholograms/DeathHolograms.java
@@ -17,8 +17,8 @@ package com.gmail.filoghost.example.deathholograms;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;

--- a/Example/PowerUps/src/main/java/com/gmail/filoghost/example/powerups/PowerUps.java
+++ b/Example/PowerUps/src/main/java/com/gmail/filoghost/example/powerups/PowerUps.java
@@ -14,8 +14,8 @@
  */
 package com.gmail.filoghost.example.powerups;
 
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;

--- a/Example/pom.xml
+++ b/Example/pom.xml
@@ -35,6 +35,11 @@
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>net.md-5</groupId>
+			<artifactId>bungeecord-chat</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/Legacy/src/main/java/com/gmail/filoghost/holograms/api/HolographicDisplaysAPI.java
+++ b/Legacy/src/main/java/com/gmail/filoghost/holograms/api/HolographicDisplaysAPI.java
@@ -21,8 +21,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -134,6 +134,11 @@
 			<groupId>me.filoghost.updatechecker</groupId>
 			<artifactId>updatechecker</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>net.md-5</groupId>
+			<artifactId>bungeecord-chat</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/HolographicDisplays.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/HolographicDisplays.java
@@ -19,9 +19,9 @@ import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import net.md_5.bungee.api.ChatColor;
 import org.bstats.bukkit.MetricsLite;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import com.gmail.filoghost.holographicdisplays.api.internal.BackendAPI;

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/commands/Colors.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/commands/Colors.java
@@ -14,7 +14,7 @@
  */
 package com.gmail.filoghost.holographicdisplays.commands;
 
-import org.bukkit.ChatColor;
+import net.md_5.bungee.api.ChatColor;
 
 public class Colors {
 

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/commands/Strings.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/commands/Strings.java
@@ -14,7 +14,7 @@
  */
 package com.gmail.filoghost.holographicdisplays.commands;
 
-import org.bukkit.ChatColor;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.CommandSender;
 
 public class Strings {

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/commands/main/subs/ReadimageCommand.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/commands/main/subs/ReadimageCommand.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
 import com.gmail.filoghost.holographicdisplays.HolographicDisplays;

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/commands/main/subs/ReadtextCommand.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/commands/main/subs/ReadtextCommand.java
@@ -21,8 +21,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
 import com.gmail.filoghost.holographicdisplays.HolographicDisplays;

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/disk/HologramLineParser.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/disk/HologramLineParser.java
@@ -14,8 +14,8 @@
  */
 package com.gmail.filoghost.holographicdisplays.disk;
 
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/image/ImageMessage.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/image/ImageMessage.java
@@ -22,10 +22,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.bukkit.ChatColor;
-
 import com.gmail.filoghost.holographicdisplays.disk.Configuration;
 import com.gmail.filoghost.holographicdisplays.exception.TooWideException;
+import net.md_5.bungee.api.ChatColor;
 
 /**
  * Huge thanks to bobacadodl for this awesome library!

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/placeholder/PlaceholdersRegister.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/placeholder/PlaceholdersRegister.java
@@ -19,8 +19,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.plugin.Plugin;
 
 import com.gmail.filoghost.holographicdisplays.HolographicDisplays;

--- a/Utils/pom.xml
+++ b/Utils/pom.xml
@@ -29,6 +29,11 @@
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>net.md-5</groupId>
+			<artifactId>bungeecord-chat</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/Utils/src/main/java/com/gmail/filoghost/holographicdisplays/util/ItemUtils.java
+++ b/Utils/src/main/java/com/gmail/filoghost/holographicdisplays/util/ItemUtils.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.bukkit.ChatColor;
+import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Material;
 
 public class ItemUtils {

--- a/Utils/src/main/java/com/gmail/filoghost/holographicdisplays/util/Utils.java
+++ b/Utils/src/main/java/com/gmail/filoghost/holographicdisplays/util/Utils.java
@@ -3,18 +3,26 @@
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
  *  (at your option) any later version.
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License
  *  along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 package com.gmail.filoghost.holographicdisplays.util;
 
+import net.md_5.bungee.api.ChatColor;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
 public class Utils {
+	/** Matches a single color code (including hex but not including other formatting such as bold). **/
+	private static final Pattern COLOR_CODE_PATTERN = Pattern.compile("§([0-9A-F]|X(§[0-9A-F]){6})", Pattern.CASE_INSENSITIVE);
 
 	/**
 	 * Converts a generic array to an array of Strings using the method toString().
@@ -26,71 +34,71 @@ public class Utils {
 		for (int i = 0; i < array.length; i++) {
 			result[i] = array[i] != null ? array[i].toString() : null;
 		}
-		
+
 		return result;
 	}
-	
-	
+
+
 	public static String limitLength(String s, int maxLength) {
 		if (s != null && s.length() > maxLength) {
 			s = s.substring(0, maxLength);
 		}
 		return s;
 	}
-	
-	
+
+
 	public static int floor(double num) {
 		int floor = (int) num;
 		return floor == num ? floor : floor - (int) (Double.doubleToRawLongBits(num) >>> 63);
 	}
-	
-	
+
+
 	public static double square(double num) {
 		return num * num;
 	}
-	
-	
+
+
 	public static String join(String[] elements, String separator, int startIndex, int endIndex) {
 		Validator.isTrue(startIndex >= 0 && startIndex < elements.length, "startIndex out of bounds");
 		Validator.isTrue(endIndex >= 0 && endIndex <= elements.length, "endIndex out of bounds");
 		Validator.isTrue(startIndex <= endIndex, "startIndex lower than endIndex");
-		
+
 		StringBuilder result = new StringBuilder();
-		
+
 		while (startIndex < endIndex) {
 			if (result.length() != 0) {
 				result.append(separator);
 			}
-			
+
 			if (elements[startIndex] != null) {
 				result.append(elements[startIndex]);
 			}
 			startIndex++;
 		}
-		
+
 		return result.toString();
 	}
-	
+
 	public static String sanitize(String s) {
 		return s != null ? s : "null";
 	}
-	
-	
+
+
 	public static boolean isThereNonNull(Object... objects) {
 		if (objects == null) {
 			return false;
 		}
-		
+
 		for (int i = 0; i < objects.length; i++) {
 			if (objects[i] != null) {
 				return true;
 			}
 		}
-		
+
 		return false;
 	}
-	
-	
+
+
 	public static boolean classExists(String className) {
 		try {
 			Class.forName(className);
@@ -99,16 +107,31 @@ public class Utils {
 			return false;
 		}
 	}
-	
+
 	public static String uncapitalize(String str) {
 		if (str == null || str.isEmpty()) {
 			return str;
 		}
-		
+
 		return new StringBuilder(str.length())
 				.append(Character.toLowerCase(str.charAt(0)))
 				.append(str.substring(1))
 				.toString();
 	}
-	
+
+	/**
+	 * @return whether the string is a single color code (including hex but not including other formatting such as bold)
+	 */
+	public static boolean isColorCode(String maybeColorCode) {
+		return COLOR_CODE_PATTERN.matcher(maybeColorCode).matches();
+	}
+
+	/**
+	 * @param colorCode see {@link #isColorCode(String)}
+	 */
+	public static ChatColor toChatColor(String colorCode) {
+		final String lowercaseColorCode = colorCode.toLowerCase(Locale.ROOT);
+		return Optional.ofNullable(ChatColor.getByChar(lowercaseColorCode.charAt(1)))
+				.orElseGet(() -> ChatColor.of("#" + lowercaseColorCode.replace("§", "").replace("x", "")));
+	}
 }

--- a/Utils/src/main/java/com/gmail/filoghost/holographicdisplays/util/Utils.java
+++ b/Utils/src/main/java/com/gmail/filoghost/holographicdisplays/util/Utils.java
@@ -3,12 +3,12 @@
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation, either version 3 of the License, or
  *  (at your option) any later version.
- *
+ *  
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details.
- *
+ *  
  *  You should have received a copy of the GNU General Public License
  *  along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -34,71 +34,71 @@ public class Utils {
 		for (int i = 0; i < array.length; i++) {
 			result[i] = array[i] != null ? array[i].toString() : null;
 		}
-
+		
 		return result;
 	}
-
-
+	
+	
 	public static String limitLength(String s, int maxLength) {
 		if (s != null && s.length() > maxLength) {
 			s = s.substring(0, maxLength);
 		}
 		return s;
 	}
-
-
+	
+	
 	public static int floor(double num) {
 		int floor = (int) num;
 		return floor == num ? floor : floor - (int) (Double.doubleToRawLongBits(num) >>> 63);
 	}
-
-
+	
+	
 	public static double square(double num) {
 		return num * num;
 	}
-
-
+	
+	
 	public static String join(String[] elements, String separator, int startIndex, int endIndex) {
 		Validator.isTrue(startIndex >= 0 && startIndex < elements.length, "startIndex out of bounds");
 		Validator.isTrue(endIndex >= 0 && endIndex <= elements.length, "endIndex out of bounds");
 		Validator.isTrue(startIndex <= endIndex, "startIndex lower than endIndex");
-
+		
 		StringBuilder result = new StringBuilder();
-
+		
 		while (startIndex < endIndex) {
 			if (result.length() != 0) {
 				result.append(separator);
 			}
-
+			
 			if (elements[startIndex] != null) {
 				result.append(elements[startIndex]);
 			}
 			startIndex++;
 		}
-
+		
 		return result.toString();
 	}
-
+	
 	public static String sanitize(String s) {
 		return s != null ? s : "null";
 	}
-
-
+	
+	
 	public static boolean isThereNonNull(Object... objects) {
 		if (objects == null) {
 			return false;
 		}
-
+		
 		for (int i = 0; i < objects.length; i++) {
 			if (objects[i] != null) {
 				return true;
 			}
 		}
-
+		
 		return false;
 	}
-
-
+	
+	
 	public static boolean classExists(String className) {
 		try {
 			Class.forName(className);
@@ -107,12 +107,12 @@ public class Utils {
 			return false;
 		}
 	}
-
+	
 	public static String uncapitalize(String str) {
 		if (str == null || str.isEmpty()) {
 			return str;
 		}
-
+		
 		return new StringBuilder(str.length())
 				.append(Character.toLowerCase(str.charAt(0)))
 				.append(str.substring(1))

--- a/Utils/src/main/java/com/gmail/filoghost/holographicdisplays/util/nbt/parser/MojangsonParseException.java
+++ b/Utils/src/main/java/com/gmail/filoghost/holographicdisplays/util/nbt/parser/MojangsonParseException.java
@@ -1,6 +1,6 @@
 package com.gmail.filoghost.holographicdisplays.util.nbt.parser;
 
-import org.bukkit.ChatColor;
+import net.md_5.bungee.api.ChatColor;
 
 import java.io.IOException;
 

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,13 @@
 				<artifactId>updatechecker</artifactId>
 				<version>1.0.0</version>
 			</dependency>
+
+			<dependency>
+				<groupId>net.md-5</groupId>
+				<artifactId>bungeecord-chat</artifactId>
+				<version>1.16-R0.1</version>
+				<scope>provided</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
1.16 adds the ability to display text in **any** color. This is done with the new `§x` color code by following it with the six hexadecimal color digits each prefixed by a `§`. For example, the color `#FF0000` is denoted by `§x§f§f§0§0§0§0`.

The Spigot ChatColor API does not support this, but the BungeeCord ChatColor API does. See https://www.spigotmc.org/threads/spigot-bungeecord-1-16-1.447405/#post-3852349 for more information.

This PR switches to that API (which, by the way, is already included in the Spigot jar).