### PR TITLE
api: Configurable line spacing

### DIFF
--- a/API/src/main/java/com/gmail/filoghost/holographicdisplays/api/Hologram.java
+++ b/API/src/main/java/com/gmail/filoghost/holographicdisplays/api/Hologram.java
@@ -216,5 +216,19 @@ public interface Hologram {
 	 * @return true if this hologram was deleted
 	 */
 	public boolean isDeleted();
-	
+
+	/**
+	 * Returns the line spacing for this hologram. By default, this is imported from the plugin configuration.
+	 * Default is 0.02, a good one for a bit more spacing can be 0.1.
+	 *
+	 * @return the line spacing
+	 */
+	double getLineSpacing();
+
+	/**
+	 * Sets the line spacing for this hologram.
+	 *
+	 * @param spacing the new line spacing
+	 */
+	void setLineSpacing(double spacing);
 }

--- a/Config/src/main/java/com/gmail/filoghost/holographicdisplays/disk/Configuration.java
+++ b/Config/src/main/java/com/gmail/filoghost/holographicdisplays/disk/Configuration.java
@@ -32,7 +32,7 @@ import org.bukkit.plugin.Plugin;
 import com.gmail.filoghost.holographicdisplays.util.ConsoleLogger;
 
 /**
- * Just a bunch of static varibles to hold the settings.
+ * Just a bunch of static variables to hold the settings.
  * Useful for fast access.
  */
 public class Configuration {

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/object/CraftHologram.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/object/CraftHologram.java
@@ -48,6 +48,7 @@ public class CraftHologram implements Hologram {
 	private boolean allowPlaceholders;
 	private long creationTimestamp;
 	private boolean deleted;
+	private double lineSpacing;
 	
 	public CraftHologram(Location location) {
 		Validator.notNull(location, "location");
@@ -57,6 +58,7 @@ public class CraftHologram implements Hologram {
 		allowPlaceholders = false;
 		creationTimestamp = System.currentTimeMillis();
 		visibilityManager = new CraftVisibilityManager(this);
+		lineSpacing = Configuration.spaceBetweenLines;
 	}
 	
 	public boolean isInChunk(Chunk chunk) {
@@ -103,7 +105,17 @@ public class CraftHologram implements Hologram {
 	public boolean isDeleted() {
 		return deleted;
 	}
-	
+
+	@Override
+	public double getLineSpacing() {
+		return lineSpacing;
+	}
+
+	@Override
+	public void setLineSpacing(double spacing) {
+		this.lineSpacing = spacing;
+	}
+
 	@Override
 	public void delete() {
 		if (!deleted) {
@@ -205,7 +217,7 @@ public class CraftHologram implements Hologram {
 			height += line.getHeight();
 		}
 		
-		height += Configuration.spaceBetweenLines * (lines.size() - 1);
+		height += lineSpacing * (lines.size() - 1);
 		return height;
 	}
 	
@@ -255,7 +267,7 @@ public class CraftHologram implements Hologram {
 				if (first) {
 					first = false;
 				} else {
-					currentY -= Configuration.spaceBetweenLines;
+					currentY -= lineSpacing;
 				}
 				
 				if (line.isSpawned()) {
@@ -288,7 +300,7 @@ public class CraftHologram implements Hologram {
 			if (first) {
 				first = false;
 			} else {
-				currentY -= Configuration.spaceBetweenLines;
+				currentY -= lineSpacing;
 			}
 			
 			line.spawn(world, x, currentY, z);
@@ -340,7 +352,7 @@ public class CraftHologram implements Hologram {
 			if (first) {
 				first = false;
 			} else {
-				currentY -= Configuration.spaceBetweenLines;
+				currentY -= lineSpacing;
 			}
 			
 			line.teleport(x, currentY, z);


### PR DESCRIPTION
This makes line spacing configurable per-hologram via the API (instead of always using the value provided by `Configuration.spaceBetweenLines`).

Note: versions aren't bumped, so this is still plugin/API 2.4.5.