### PR TITLE
Fixed and added latest ProtocolLib compatibility

### DIFF
--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/bridge/protocollib/current/DebugHelper.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/bridge/protocollib/current/DebugHelper.java
@@ -16,12 +16,13 @@ package com.gmail.filoghost.holographicdisplays.bridge.protocollib.current;
 
 import java.util.Map;
 
-import com.comphenix.net.sf.cglib.proxy.Factory;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.reflect.EquivalentConverter;
 import com.comphenix.protocol.reflect.PrettyPrinter;
 import com.comphenix.protocol.reflect.PrettyPrinter.ObjectPrinter;
+import com.comphenix.protocol.utility.ByteBuddyFactory;
+import com.comphenix.protocol.utility.ByteBuddyGenerated;
 import com.comphenix.protocol.utility.HexDumper;
 import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.wrappers.BukkitConverters;
@@ -57,9 +58,13 @@ public class DebugHelper {
 		Class<?> clazz = packet.getClass();
 		
 		// Get the first Minecraft super class
-		while (clazz != null && clazz != Object.class &&
-				(!MinecraftReflection.isMinecraftClass(clazz) || 
-				 Factory.class.isAssignableFrom(clazz))) {
+		while (clazz != null
+				&& clazz != Object.class
+				// Check if the super class is a generated class/factory from ByteBuddy, the new
+				// ProtocolLib bytecode library replacing cglib
+				&& (!MinecraftReflection.isMinecraftClass(clazz)
+				|| ByteBuddyGenerated.class.isAssignableFrom(clazz)
+				|| ByteBuddyFactory.class.isAssignableFrom(clazz))) {
 			clazz = clazz.getSuperclass();
 		}
 		

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/bridge/protocollib/current/ProtocolLibHookImpl.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/bridge/protocollib/current/ProtocolLibHookImpl.java
@@ -22,7 +22,6 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
-import com.comphenix.net.sf.cglib.proxy.Factory;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.events.ListenerPriority;

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
 			<dependency>
 				<groupId>com.github.dmulloy2</groupId>
 				<artifactId>ProtocolLib</artifactId>
-				<version>4.5.0</version>
+				<version>4.6.0</version>
 				<scope>provided</scope>
 			</dependency>
 	


### PR DESCRIPTION
Fixed and added the latest ProtocolLib compatibility. This drops support with the previous library *exclusively* if the debug helper is used

Changes made:
- Changed debug check to check for bytebuddy generated items instead of CGLib Factory

View ProtocolLib changes:
- 4.5.0: https://github.com/dmulloy2/ProtocolLib/blob/4bc9e8b7b78196c99d95330005171ced8ed5b73d/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java
- 4.6.0: https://github.com/dmulloy2/ProtocolLib/blob/master/src/main/java/com/comphenix/protocol/injector/netty/ChannelInjector.java