### PR TITLE
Fix possible memory leak caused by last damage cause

### DIFF
--- a/NMS/v1_10_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_10_R1/CraftNMSArmorStand.java
+++ b/NMS/v1_10_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_10_R1/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_10_R1.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -88,5 +89,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void setMomentum(Vector value) { }
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_10_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_10_R1/CraftNMSItem.java
+++ b/NMS/v1_10_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_10_R1/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_10_R1.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -55,7 +56,8 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void setMomentum(Vector value) { }
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Item
 	@Override public void setItemStack(ItemStack stack) { }
 	@Override public void setPickupDelay(int delay) { }

--- a/NMS/v1_10_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_10_R1/CraftNMSSlime.java
+++ b/NMS/v1_10_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_10_R1/CraftNMSSlime.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_10_R1.entity.CraftSlime;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
@@ -68,6 +69,7 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void setMomentum(Vector value) { }
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 
 	// Methods from Slime
 	@Override public void setSize(int size) { }

--- a/NMS/v1_11_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_11_R1/CraftNMSArmorStand.java
+++ b/NMS/v1_11_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_11_R1/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_11_R1.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -88,5 +89,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void setMomentum(Vector value) { }
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_11_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_11_R1/CraftNMSItem.java
+++ b/NMS/v1_11_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_11_R1/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_11_R1.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -55,7 +56,8 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void setMomentum(Vector value) { }
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Item
 	@Override public void setItemStack(ItemStack stack) { }
 	@Override public void setPickupDelay(int delay) { }

--- a/NMS/v1_11_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_11_R1/CraftNMSSlime.java
+++ b/NMS/v1_11_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_11_R1/CraftNMSSlime.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_11_R1.entity.CraftSlime;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
@@ -68,6 +69,7 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void setMomentum(Vector value) { }
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 
 	// Methods from Slime
 	@Override public void setSize(int size) { }

--- a/NMS/v1_12_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_12_R1/CraftNMSArmorStand.java
+++ b/NMS/v1_12_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_12_R1/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_12_R1.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -89,5 +90,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void setMomentum(Vector value) { }
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 }

--- a/NMS/v1_12_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_12_R1/CraftNMSItem.java
+++ b/NMS/v1_12_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_12_R1/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_12_R1.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -55,7 +56,8 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void setMomentum(Vector value) { }
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Item
 	@Override public void setItemStack(ItemStack stack) { }
 	@Override public void setPickupDelay(int delay) { }

--- a/NMS/v1_12_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_12_R1/CraftNMSSlime.java
+++ b/NMS/v1_12_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_12_R1/CraftNMSSlime.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_12_R1.entity.CraftSlime;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
@@ -68,6 +69,7 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void setMomentum(Vector value) { }
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 
 	// Methods from Slime
 	@Override public void setSize(int size) { }

--- a/NMS/v1_13_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R1/CraftNMSArmorStand.java
+++ b/NMS/v1_13_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R1/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_13_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_13_R1.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -90,6 +91,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void setMomentum(Vector value) { }
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_13_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R1/CraftNMSItem.java
+++ b/NMS/v1_13_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R1/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_13_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_13_R1.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -55,7 +56,8 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void setMomentum(Vector value) { }
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Item
 	@Override public void setItemStack(ItemStack stack) { }
 	@Override public void setPickupDelay(int delay) { }

--- a/NMS/v1_13_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R1/CraftNMSSlime.java
+++ b/NMS/v1_13_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R1/CraftNMSSlime.java
@@ -22,6 +22,7 @@ import org.bukkit.craftbukkit.v1_13_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_13_R1.entity.CraftSlime;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
@@ -70,7 +71,7 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void setMomentum(Vector value) { }
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 
 	// Methods from Slime
 	@Override public void setSize(int size) { }

--- a/NMS/v1_13_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R2/CraftNMSArmorStand.java
+++ b/NMS/v1_13_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R2/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_13_R2.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -91,6 +92,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_13_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R2/CraftNMSItem.java
+++ b/NMS/v1_13_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R2/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_13_R2.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -56,7 +57,8 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Item
 	@Override public void setItemStack(ItemStack stack) { }
 	@Override public void setPickupDelay(int delay) { }

--- a/NMS/v1_13_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R2/CraftNMSSlime.java
+++ b/NMS/v1_13_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_13_R2/CraftNMSSlime.java
@@ -22,6 +22,7 @@ import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_13_R2.entity.CraftSlime;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.loot.LootTable;
 import org.bukkit.potion.PotionEffect;
@@ -72,7 +73,8 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void setSilent(boolean flag) { }
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Mob
 	@Override public void setLootTable(LootTable table) { }
 	@Override public void setSeed(long seed) { }

--- a/NMS/v1_14_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_14_R1/CraftNMSArmorStand.java
+++ b/NMS/v1_14_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_14_R1/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -91,6 +92,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_14_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_14_R1/CraftNMSItem.java
+++ b/NMS/v1_14_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_14_R1/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -61,5 +62,6 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 }

--- a/NMS/v1_14_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_14_R1/CraftNMSSlime.java
+++ b/NMS/v1_14_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_14_R1/CraftNMSSlime.java
@@ -22,6 +22,7 @@ import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftSlime;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.loot.LootTable;
 import org.bukkit.potion.PotionEffect;
@@ -81,5 +82,6 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 
 }

--- a/NMS/v1_15_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_15_R1/CraftNMSArmorStand.java
+++ b/NMS/v1_15_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_15_R1/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -91,6 +92,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_15_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_15_R1/CraftNMSItem.java
+++ b/NMS/v1_15_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_15_R1/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -61,5 +62,6 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_15_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_15_R1/CraftNMSSlime.java
+++ b/NMS/v1_15_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_15_R1/CraftNMSSlime.java
@@ -22,6 +22,7 @@ import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftSlime;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.loot.LootTable;
 import org.bukkit.potion.PotionEffect;
@@ -81,5 +82,6 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 
 }

--- a/NMS/v1_16_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R1/CraftNMSArmorStand.java
+++ b/NMS/v1_16_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R1/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -91,6 +92,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_16_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R1/CraftNMSItem.java
+++ b/NMS/v1_16_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R1/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -61,5 +62,6 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 }

--- a/NMS/v1_16_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R1/CraftNMSSlime.java
+++ b/NMS/v1_16_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R1/CraftNMSSlime.java
@@ -22,6 +22,7 @@ import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftSlime;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.loot.LootTable;
 import org.bukkit.potion.PotionEffect;
@@ -81,5 +82,6 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 
 }

--- a/NMS/v1_16_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R2/CraftNMSArmorStand.java
+++ b/NMS/v1_16_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R2/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -91,6 +92,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_16_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R2/CraftNMSItem.java
+++ b/NMS/v1_16_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R2/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -61,5 +62,6 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 }

--- a/NMS/v1_16_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R2/CraftNMSSlime.java
+++ b/NMS/v1_16_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R2/CraftNMSSlime.java
@@ -22,6 +22,7 @@ import org.bukkit.craftbukkit.v1_16_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R2.entity.CraftSlime;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.loot.LootTable;
 import org.bukkit.potion.PotionEffect;
@@ -81,5 +82,6 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 
 }

--- a/NMS/v1_16_R3/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R3/CraftNMSArmorStand.java
+++ b/NMS/v1_16_R3/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R3/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -91,6 +92,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_16_R3/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R3/CraftNMSItem.java
+++ b/NMS/v1_16_R3/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R3/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -61,5 +62,6 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 }

--- a/NMS/v1_16_R3/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R3/CraftNMSSlime.java
+++ b/NMS/v1_16_R3/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_16_R3/CraftNMSSlime.java
@@ -22,6 +22,7 @@ import org.bukkit.craftbukkit.v1_16_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R3.entity.CraftSlime;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.loot.LootTable;
 import org.bukkit.potion.PotionEffect;
@@ -81,5 +82,6 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void setTicksLived(int value) { }
 	@Override public void setPersistent(boolean flag) { }
 	@Override public void setRotation(float yaw, float pitch) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 
 }

--- a/NMS/v1_8_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_8_R2/CraftNMSArmorStand.java
+++ b/NMS/v1_8_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_8_R2/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_8_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_8_R2.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -77,5 +78,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void playEffect(EntityEffect effect) { }
 	@Override public void setCustomName(String name) { }
 	@Override public void setCustomNameVisible(boolean flag) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_8_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_8_R2/CraftNMSItem.java
+++ b/NMS/v1_8_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_8_R2/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_8_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_8_R2.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -49,7 +50,8 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void playEffect(EntityEffect effect) { }
 	@Override public void setCustomName(String name) { }
 	@Override public void setCustomNameVisible(boolean flag) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Item
 	@Override public void setItemStack(ItemStack stack) { }
 	@Override public void setPickupDelay(int delay) { }

--- a/NMS/v1_8_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_8_R2/CraftNMSSlime.java
+++ b/NMS/v1_8_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_8_R2/CraftNMSSlime.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_8_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_8_R2.entity.CraftSlime;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
@@ -57,7 +58,8 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void playEffect(EntityEffect effect) { }
 	@Override public void setCustomName(String name) { }
 	@Override public void setCustomNameVisible(boolean flag) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Slime
 	@Override public void setSize(int size) { }
 }

--- a/NMS/v1_8_R3/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_8_R3/CraftNMSArmorStand.java
+++ b/NMS/v1_8_R3/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_8_R3/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_8_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -77,5 +78,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void playEffect(EntityEffect effect) { }
 	@Override public void setCustomName(String name) { }
 	@Override public void setCustomNameVisible(boolean flag) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_8_R3/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_8_R3/CraftNMSItem.java
+++ b/NMS/v1_8_R3/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_8_R3/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_8_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -49,7 +50,8 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void playEffect(EntityEffect effect) { }
 	@Override public void setCustomName(String name) { }
 	@Override public void setCustomNameVisible(boolean flag) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Item
 	@Override public void setItemStack(ItemStack stack) { }
 	@Override public void setPickupDelay(int delay) { }

--- a/NMS/v1_8_R3/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_8_R3/CraftNMSSlime.java
+++ b/NMS/v1_8_R3/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_8_R3/CraftNMSSlime.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_8_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_8_R3.entity.CraftSlime;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
@@ -57,7 +58,8 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void playEffect(EntityEffect effect) { }
 	@Override public void setCustomName(String name) { }
 	@Override public void setCustomNameVisible(boolean flag) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Slime
 	@Override public void setSize(int size) { }
 }

--- a/NMS/v1_9_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_9_R1/CraftNMSArmorStand.java
+++ b/NMS/v1_9_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_9_R1/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_9_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_9_R1.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -78,5 +79,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void playEffect(EntityEffect effect) { }
 	@Override public void setCustomName(String name) { }
 	@Override public void setCustomNameVisible(boolean flag) { }
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
 	
 }

--- a/NMS/v1_9_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_9_R1/CraftNMSItem.java
+++ b/NMS/v1_9_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_9_R1/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_9_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_9_R1.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -49,7 +50,8 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void playEffect(EntityEffect effect) { }
 	@Override public void setCustomName(String name) { }
 	@Override public void setCustomNameVisible(boolean flag) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Item
 	@Override public void setItemStack(ItemStack stack) { }
 	@Override public void setPickupDelay(int delay) { }

--- a/NMS/v1_9_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_9_R1/CraftNMSSlime.java
+++ b/NMS/v1_9_R1/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_9_R1/CraftNMSSlime.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_9_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_9_R1.entity.CraftSlime;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
@@ -57,7 +58,8 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void playEffect(EntityEffect effect) { }
 	@Override public void setCustomName(String name) { }
 	@Override public void setCustomNameVisible(boolean flag) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Slime
 	@Override public void setSize(int size) { }
 	

--- a/NMS/v1_9_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_9_R2/CraftNMSArmorStand.java
+++ b/NMS/v1_9_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_9_R2/CraftNMSArmorStand.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_9_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_9_R2.entity.CraftArmorStand;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -78,5 +79,6 @@ public class CraftNMSArmorStand extends CraftArmorStand {
 	@Override public void playEffect(EntityEffect effect) { }
 	@Override public void setCustomName(String name) { }
 	@Override public void setCustomNameVisible(boolean flag) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 }

--- a/NMS/v1_9_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_9_R2/CraftNMSItem.java
+++ b/NMS/v1_9_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_9_R2/CraftNMSItem.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_9_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_9_R2.entity.CraftItem;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -49,7 +50,8 @@ public class CraftNMSItem extends CraftItem {
 	@Override public void playEffect(EntityEffect effect) { }
 	@Override public void setCustomName(String name) { }
 	@Override public void setCustomNameVisible(boolean flag) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Item
 	@Override public void setItemStack(ItemStack stack) { }
 	@Override public void setPickupDelay(int delay) { }

--- a/NMS/v1_9_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_9_R2/CraftNMSSlime.java
+++ b/NMS/v1_9_R2/src/main/java/com/gmail/filoghost/holographicdisplays/nms/v1_9_R2/CraftNMSSlime.java
@@ -21,6 +21,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_9_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_9_R2.entity.CraftSlime;
 import org.bukkit.entity.Entity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
@@ -57,7 +58,8 @@ public class CraftNMSSlime extends CraftSlime {
 	@Override public void playEffect(EntityEffect effect) { }
 	@Override public void setCustomName(String name) { }
 	@Override public void setCustomNameVisible(boolean flag) { }
-	
+	@Override public void setLastDamageCause(EntityDamageEvent event) { }
+
 	// Methods from Slime
 	@Override public void setSize(int size) { }
 	

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -27,6 +27,11 @@
 			<id>codemc-repo</id>
 			<url>https://repo.codemc.io/repository/maven-public/</url>
 		</repository>
+
+		<repository>
+			<id>dmulloy2-repo</id>
+			<url>https://repo.dmulloy2.net/repository/public/</url>
+		</repository>
 	</repositories>
 
 	<dependencies>
@@ -131,8 +136,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.github.dmulloy2</groupId>
+			<groupId>com.comphenix.protocol</groupId>
 			<artifactId>ProtocolLib</artifactId>
+			<version>4.5.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
### **Cause**
When an entity is attached by a player or a projectile or a creeper that explodes that might have been hitten by a player, can cause a vicious circle. 

### **Issue**
By default, the server keeps in memory the lastDamageCause (that you can find its field in the CraftEntity class).
Due to a server issue, the lastDamageCause field may be kept in the memory even when the world is unloaded.

The memory leak was discovered with the YourKit memory analyzer.

![image](https://user-images.githubusercontent.com/9408687/120908616-3bfaec80-c66c-11eb-85df-047a26fc8680.png)
