### PR TITLE
Improve the API of Holographic Displays:

### DIFF
--- a/API/src/main/java/com/gmail/filoghost/holographicdisplays/api/Hologram.java
+++ b/API/src/main/java/com/gmail/filoghost/holographicdisplays/api/Hologram.java
@@ -22,12 +22,21 @@ import com.gmail.filoghost.holographicdisplays.api.line.HologramLine;
 import com.gmail.filoghost.holographicdisplays.api.line.ItemLine;
 import com.gmail.filoghost.holographicdisplays.api.line.TextLine;
 
+import java.util.Collection;
+
 /**
  * An object made of various lines, that can be items or holograms.
  * Holographic lines appear as a nametag without any entity below.
  * To create one, please see {@link HologramsAPI#createHologram(org.bukkit.plugin.Plugin, Location)}.
  */
 public interface Hologram {
+	/**
+	 * Get the Hologram name when available
+	 * @return the name of the hologram, null when no name was specified
+	 */
+	default String getName() {
+		return null;
+	}
 	
 	/**
 	 * Appends a text line to end of this hologram.
@@ -45,8 +54,30 @@ public interface Hologram {
 	 * @return the new ItemLine appended
 	 */
 	public ItemLine appendItemLine(ItemStack itemStack);
-	
-	
+
+	/**
+	 * Appends multiple serialized lines and deserialize it.
+	 *
+	 * @param lines the lines to deserialize
+	 * @throws IllegalArgumentException when unable to parse the lines
+	 */
+	public void deserializeLines(Collection<String> lines) throws IllegalArgumentException;
+
+	/**
+	 * Appends a single line and deserialize the content
+	 *
+	 * @param line the line to deserialize
+	 * @throws IllegalArgumentException when unable to parse the line
+	 */
+	public void deserializeLine(String line) throws IllegalArgumentException;
+
+	/**
+	 * Serialize the lines and return it. The collection is a copy and modifications doesn't have effects
+	 *
+	 * @return copy of the serialized lines.
+	 */
+	public Collection<String> serializeLines();
+
 	/**
 	 * Inserts a text line in this hologram.
 	 * 

--- a/API/src/main/java/com/gmail/filoghost/holographicdisplays/api/HologramsAPI.java
+++ b/API/src/main/java/com/gmail/filoghost/holographicdisplays/api/HologramsAPI.java
@@ -57,6 +57,26 @@ public class HologramsAPI {
 	public static Collection<Hologram> getHolograms(Plugin plugin) {
 		return BackendAPI.getImplementation().getHolograms(plugin);
 	}
+
+	/**
+	 * Finds all the holograms owned by the HolographicDisplays itself
+	 *
+	 * @return the holograms created by HolographicDisplay. the Collection is a copy
+	 * and modifying it has no effect on the holograms.
+	 */
+	public static Collection<Hologram> getHolographicDisplayHolograms() {
+		return BackendAPI.getImplementation().getHolographicDisplayHolograms();
+	}
+
+	/**
+	 * Find the hologram specified by the name
+	 *
+	 * @param name the name of the hologram
+	 * @return the hologram created by HolographicDisplay, null when not found
+	 */
+	public static Hologram getHolographicDisplayHologram(String name) {
+		return BackendAPI.getImplementation().getHolographicDisplayHologram(name);
+	}
 	
 	
 	/**

--- a/API/src/main/java/com/gmail/filoghost/holographicdisplays/api/internal/BackendAPI.java
+++ b/API/src/main/java/com/gmail/filoghost/holographicdisplays/api/internal/BackendAPI.java
@@ -53,5 +53,7 @@ public abstract class BackendAPI {
 
 	public abstract boolean isHologramEntity(Entity bukkitEntity);	
 	
+	public abstract Collection<Hologram> getHolographicDisplayHolograms();
 
+	public abstract Hologram getHolographicDisplayHologram(String name);
 }

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/disk/HologramDatabase.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/disk/HologramDatabase.java
@@ -17,10 +17,12 @@ package com.gmail.filoghost.holographicdisplays.disk;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 
+import com.gmail.filoghost.holographicdisplays.object.CraftHologram;
 import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -68,23 +70,25 @@ public class HologramDatabase {
 		Location loc = LocationSerializer.locationFromString(locationString);
 		
 		NamedHologram hologram = new NamedHologram(loc, name);
-
-		for (String line : lines) {
-			hologram.getLinesUnsafe().add(HologramLineParser.parseLine(hologram, line, false));
-		}
-		
+		addDeserializedLines(hologram, lines);
 		return hologram;
 	}
 	
 	public static String serializeHologramLine(CraftHologramLine line) {
 		return line.getSerializedConfigValue();
 	}
+
+	public static void addDeserializedLines(CraftHologram hologram, Collection<String> lines) throws HologramLineParseException {
+		for (String line : lines) {
+			hologram.getLinesUnsafe().add(HologramLineParser.parseLine(hologram, line, false));
+		}
+	}
 	
 	public static void deleteHologram(String name) {
 		config.set(name, null);
 	}
 	
-	public static void saveHologram(NamedHologram hologram) {		
+	public static void saveHologram(NamedHologram hologram) {
 		List<String> serializedLines = new ArrayList<>();
 		for (CraftHologramLine line : hologram.getLinesUnsafe()) {
 			serializedLines.add(serializeHologramLine(line));

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/disk/HologramLineParser.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/disk/HologramLineParser.java
@@ -20,7 +20,7 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 import com.gmail.filoghost.holographicdisplays.exception.HologramLineParseException;
-import com.gmail.filoghost.holographicdisplays.object.NamedHologram;
+import com.gmail.filoghost.holographicdisplays.object.CraftHologram;
 import com.gmail.filoghost.holographicdisplays.object.line.CraftHologramLine;
 import com.gmail.filoghost.holographicdisplays.object.line.CraftItemLine;
 import com.gmail.filoghost.holographicdisplays.object.line.CraftTextLine;
@@ -32,7 +32,7 @@ import com.gmail.filoghost.holographicdisplays.util.nbt.parser.MojangsonParser;
 public class HologramLineParser {
 	
 	
-	public static CraftHologramLine parseLine(NamedHologram hologram, String serializedLine, boolean checkMaterialValidity) throws HologramLineParseException {
+	public static CraftHologramLine parseLine(CraftHologram hologram, String serializedLine, boolean checkMaterialValidity) throws HologramLineParseException {
 		CraftHologramLine hologramLine;
 		
 		if (serializedLine.toLowerCase().startsWith("icon:")) {

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/object/CraftHologram.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/object/CraftHologram.java
@@ -15,8 +15,12 @@
 package com.gmail.filoghost.holographicdisplays.object;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
+import com.gmail.filoghost.holographicdisplays.disk.HologramDatabase;
+import com.gmail.filoghost.holographicdisplays.exception.HologramLineParseException;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -162,7 +166,36 @@ public class CraftHologram implements Hologram {
 		refreshSingleLines();
 		return line;
 	}
-	
+
+	@Override
+	public void deserializeLines(Collection<String> lines) throws IllegalArgumentException {
+		Validator.isTrue(!deleted, "hologram already deleted");
+		Validator.notNull(lines, "lines");
+
+		try {
+			HologramDatabase.addDeserializedLines(this, lines);
+		} catch (HologramLineParseException e) {
+			throw new IllegalArgumentException("Unable to deserialize lines", e);
+		}
+	}
+
+	@Override
+	public void deserializeLine(String line) {
+		Validator.isTrue(!deleted, "hologram already deleted");
+		Validator.notNull(line, "line");
+
+		deserializeLines(Collections.singleton(line));
+	}
+
+	@Override
+	public Collection<String> serializeLines() {
+		List<String> serialized = new ArrayList<>();
+		for (CraftHologramLine line : lines) {
+			serialized.add(HologramDatabase.serializeHologramLine(line));
+		}
+		return serialized;
+	}
+
 	@Override
 	public void removeLine(int index) {
 		Validator.isTrue(!deleted, "hologram already deleted");

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/object/DefaultBackendAPI.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/object/DefaultBackendAPI.java
@@ -15,6 +15,7 @@
 package com.gmail.filoghost.holographicdisplays.object;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -61,6 +62,14 @@ public class DefaultBackendAPI extends BackendAPI {
 	public Collection<Hologram> getHolograms(Plugin plugin) {
 		Validator.notNull(plugin, "plugin");
 		return PluginHologramManager.getHolograms(plugin);
+	}
+
+	public Collection<Hologram> getHolographicDisplayHolograms() {
+		return Collections.unmodifiableList(NamedHologramManager.getHolograms());
+	}
+
+	public Hologram getHolographicDisplayHologram(String name) {
+		return NamedHologramManager.getHologram(name);
 	}
 
 	public Collection<String> getRegisteredPlaceholders(Plugin plugin) {

--- a/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/object/NamedHologram.java
+++ b/Plugin/src/main/java/com/gmail/filoghost/holographicdisplays/object/NamedHologram.java
@@ -26,6 +26,11 @@ public class NamedHologram extends CraftHologram {
 		setAllowPlaceholders(true);
 	}
 
+	/**
+	 * Get the Hologram name when available
+	 * @return the name of the hologram, null when no name was specified
+	 */
+	@Override
 	public String getName() {
 		return name;
 	}


### PR DESCRIPTION
* Access existing holograms from HolographicDisplay
* Expose the name of a hologram (when existing, else null)
* Add methods to add serialized text and get serialized text from Holograms

Some background informations:
I want to access existing HolographicDisplay Holograms (convert those to "plugin holograms") and store them in my plugin. I need the name reference to find those Holograms.

For text storage it's nice to have a method to serialize / deserialize text. As HolographicDisplay has to handle backwards compatibility itself for existing NamedHolograms this should be no problem.