### PR TITLE
Ability to get access to InternalHologramEditor from another plugin + Fix message compatible versions

### DIFF
--- a/plugin/src/main/java/me/filoghost/holographicdisplays/plugin/HolographicDisplays.java
+++ b/plugin/src/main/java/me/filoghost/holographicdisplays/plugin/HolographicDisplays.java
@@ -60,6 +60,7 @@ public class HolographicDisplays extends FCommonsPlugin {
     private InternalHologramManager internalHologramManager;
     private APIHologramManager apiHologramManager;
     private V2HologramManager v2HologramManager;
+    private HologramCommandManager hologramCommandManager;
 
     @Override
     public void onCheckedEnable() throws PluginEnableException {
@@ -92,7 +93,7 @@ public class HolographicDisplays extends FCommonsPlugin {
         try {
             nmsManager = NMSVersion.getCurrent().createNMSManager(errorCollector);
         } catch (UnknownVersionException e) {
-            throw new PluginEnableException("Holographic Displays only supports Spigot from 1.8 to 1.17.");
+            throw new PluginEnableException("Holographic Displays only supports Spigot from 1.8 to 1.18.");
         } catch (OutdatedVersionException e) {
             throw new PluginEnableException("Holographic Displays only supports " + e.getMinimumSupportedVersion() + " and above.");
         } catch (Throwable t) {
@@ -124,7 +125,8 @@ public class HolographicDisplays extends FCommonsPlugin {
         }
 
         // Commands
-        new HologramCommandManager(this, internalHologramManager, configManager).register(this);
+        hologramCommandManager = new HologramCommandManager(this, internalHologramManager, configManager);
+        hologramCommandManager.register(this);
 
         // Listeners
         registerListener(new PlayerListener(nmsManager, lineTrackerManager, lineClickListener));
@@ -195,6 +197,8 @@ public class HolographicDisplays extends FCommonsPlugin {
             }
         }
     }
+
+    public HologramCommandManager getHologramCommandManager() { return hologramCommandManager; }
 
     public static HolographicDisplays getInstance() {
         return instance;

--- a/plugin/src/main/java/me/filoghost/holographicdisplays/plugin/commands/HologramCommandManager.java
+++ b/plugin/src/main/java/me/filoghost/holographicdisplays/plugin/commands/HologramCommandManager.java
@@ -52,15 +52,18 @@ import java.util.logging.Level;
 public class HologramCommandManager extends SubCommandManager {
 
     private final HolographicDisplays holographicDisplays;
+    private final InternalHologramEditor hologramEditor;
     private final List<HologramSubCommand> subCommands;
     private final HelpCommand helpCommand;
+
+    public InternalHologramEditor getInternalHologramEditor() { return hologramEditor; }
 
     public HologramCommandManager(
             HolographicDisplays holographicDisplays,
             InternalHologramManager internalHologramManager,
             ConfigManager configManager) {
         setName("holograms");
-        InternalHologramEditor hologramEditor = new InternalHologramEditor(internalHologramManager, configManager);
+        hologramEditor = new InternalHologramEditor(internalHologramManager, configManager);
         this.holographicDisplays = holographicDisplays;
         this.helpCommand = new HelpCommand(this);
         this.subCommands = new ArrayList<>();


### PR DESCRIPTION
1. We need to save holograms to database. In previous versions all have worked because classes vere static, now we need instance of InternalHologramEditor. This pull request is providing InternalHologramEditor into HologramCommandManager class and HologramCommandManager instance into main class.

2. Fixed message Holographic Displays only supports Spigot from (1.8 - 1.17) -> (1.8 - 1.18)