### PR TITLE
Prevent npe spam on chunk load/unload

### DIFF
--- a/core/src/main/java/me/filoghost/holographicdisplays/core/base/BaseHologramManager.java
+++ b/core/src/main/java/me/filoghost/holographicdisplays/core/base/BaseHologramManager.java
@@ -36,7 +36,7 @@ public abstract class BaseHologramManager<H extends BaseHologram> {
         Iterator<H> iterator = holograms.iterator();
         while (iterator.hasNext()) {
             H hologram = iterator.next();
-            if (condition.test(hologram)) {
+            if (hologram != null && condition.test(hologram)) {
                 iterator.remove();
                 hologram.setDeleted();
             }
@@ -47,6 +47,8 @@ public abstract class BaseHologramManager<H extends BaseHologram> {
         Iterator<H> iterator = holograms.iterator();
         while (iterator.hasNext()) {
             H hologram = iterator.next();
+            if (hologram == null) continue;
+
             iterator.remove();
             hologram.setDeleted();
         }
@@ -54,24 +56,32 @@ public abstract class BaseHologramManager<H extends BaseHologram> {
 
     public void onWorldLoad(World world) {
         for (H hologram : holograms) {
+            if (hologram == null) continue;
+
             hologram.onWorldLoad(world);
         }
     }
 
     public void onWorldUnload(World world) {
         for (H hologram : holograms) {
+            if (hologram == null) continue;
+
             hologram.onWorldUnload(world);
         }
     }
 
     public void onChunkLoad(Chunk chunk) {
         for (H hologram : holograms) {
+            if (hologram == null) continue;
+
             hologram.onChunkLoad(chunk);
         }
     }
 
     public void onChunkUnload(Chunk chunk) {
         for (H hologram : holograms) {
+            if (hologram == null) continue;
+
             hologram.onChunkUnload(chunk);
         }
     }


### PR DESCRIPTION
While using HolographicDisplays in my server I got a lot of npe's spamming my console.
I checked my code once more to see if I did anything wrong using the api and I couldn't find a mistake that would result in a npe.

So I have fixed this by adding null safety checks to the BaseHologramManager class.

Some console lines:
![afbeelding](https://user-images.githubusercontent.com/48173954/177016332-0f9d1ff3-39df-420b-9636-822b76f1d74f.png)
