### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Development Builds: https://ci.codemc.io/job/filoghost/job/HolographicDisplays
 
 ```xml
 <dependency>
-    <groupId>com.gmail.filoghost.holographicdisplays</groupId>
+    <groupId>me.filoghost.holographicdisplays</groupId>
     <artifactId>holographicdisplays-api</artifactId>
-    <version>2.4.9</version>
+    <version>3.0.1-20221113.231429-3</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -32,7 +32,7 @@ maven {
 ```
 
 ```groovy
-compileOnly 'com.gmail.filoghost.holographicdisplays:holographicdisplays-api:2.4.9'
+compileOnly 'me.filoghost.holographicdisplays:holographicdisplays-api:3.0.1-20221113.231429-3'
 ```
 
 ## License


### PR DESCRIPTION
This is an old documentation. groupId is changed and the wiki (https://github.com/filoghost/HolographicDisplays/wiki/Basic-tutorial) is updated to the new API version. In fact in version 2.4.9 there is not even the HolographicDisplaysAPI class