### PR TITLE
Allow plugin to run on unsupported versions

### DIFF
--- a/core/src/main/java/me/filoghost/holographicdisplays/core/HolographicDisplaysCore.java
+++ b/core/src/main/java/me/filoghost/holographicdisplays/core/HolographicDisplaysCore.java
@@ -42,7 +42,7 @@ public class HolographicDisplaysCore {
         try {
             nmsManager = NMSVersion.getCurrent().createNMSManager(errorCollector);
         } catch (UnknownVersionException e) {
-            if (YamlConfiguration.loadConfiguration(new File(plugin.getDataFolder() + "/config.yml).getBoolean("run-on-unsupported-versions" == true) {
+            if (YamlConfiguration.loadConfiguration(new File(plugin.getDataFolder() + "/config.yml").getBoolean("run-on-unsupported-versions" == true) {
                 Bukkit.getServer().getConsoleSender().sendMessage("You are running an unsupported version of Spigot");
                 Bukkit.getServer().getConsoleSender().sendMessage("Functionality will be unstable/not work, and you will get no support");
             } else {

--- a/core/src/main/java/me/filoghost/holographicdisplays/core/HolographicDisplaysCore.java
+++ b/core/src/main/java/me/filoghost/holographicdisplays/core/HolographicDisplaysCore.java
@@ -42,7 +42,7 @@ public class HolographicDisplaysCore {
         try {
             nmsManager = NMSVersion.getCurrent().createNMSManager(errorCollector);
         } catch (UnknownVersionException e) {
-            if (YamlConfiguration.loadConfiguration(new File(plugin.getDataFolder() + "/config.yml").getBoolean("run-on-unsupported-versions") == true) {
+            if (YamlConfiguration.loadConfiguration(new File(plugin.getDataFolder() + "/config.yml")).getBoolean("run-on-unsupported-versions") == true) {
                 Bukkit.getServer().getConsoleSender().sendMessage("You are running an unsupported version of Spigot");
                 Bukkit.getServer().getConsoleSender().sendMessage("Functionality will be unstable/not work, and you will get no support");
             } else {

--- a/core/src/main/java/me/filoghost/holographicdisplays/core/HolographicDisplaysCore.java
+++ b/core/src/main/java/me/filoghost/holographicdisplays/core/HolographicDisplaysCore.java
@@ -42,7 +42,7 @@ public class HolographicDisplaysCore {
         try {
             nmsManager = NMSVersion.getCurrent().createNMSManager(errorCollector);
         } catch (UnknownVersionException e) {
-            if (YamlConfiguration.loadConfiguration(new File(plugin.getDataFolder() + "/config.yml").getBoolean("run-on-unsupported-versions" == true) {
+            if (YamlConfiguration.loadConfiguration(new File(plugin.getDataFolder() + "/config.yml").getBoolean("run-on-unsupported-versions") == true) {
                 Bukkit.getServer().getConsoleSender().sendMessage("You are running an unsupported version of Spigot");
                 Bukkit.getServer().getConsoleSender().sendMessage("Functionality will be unstable/not work, and you will get no support");
             } else {

--- a/core/src/main/java/me/filoghost/holographicdisplays/core/HolographicDisplaysCore.java
+++ b/core/src/main/java/me/filoghost/holographicdisplays/core/HolographicDisplaysCore.java
@@ -6,6 +6,7 @@
 package me.filoghost.holographicdisplays.core;
 
 import com.gmail.filoghost.holographicdisplays.api.internal.HologramsAPIProvider;
+import java.io.File;
 import me.filoghost.fcommons.FCommonsPlugin.PluginEnableException;
 import me.filoghost.fcommons.logging.ErrorCollector;
 import me.filoghost.holographicdisplays.api.internal.HolographicDisplaysAPIProvider;
@@ -26,6 +27,7 @@ import me.filoghost.holographicdisplays.core.tick.TickingTask;
 import me.filoghost.holographicdisplays.core.tracking.LineTrackerManager;
 import me.filoghost.holographicdisplays.nms.common.NMSManager;
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
@@ -40,7 +42,12 @@ public class HolographicDisplaysCore {
         try {
             nmsManager = NMSVersion.getCurrent().createNMSManager(errorCollector);
         } catch (UnknownVersionException e) {
-            throw new PluginEnableException("Holographic Displays only supports Spigot from 1.8 to 1.18.2.");
+            if (YamlConfiguration.loadConfiguration(new File(plugin.getDataFolder() + "/config.yml).getBoolean("run-on-unsupported-versions" == true) {
+                Bukkit.getServer().getConsoleSender().sendMessage("You are running an unsupported version of Spigot");
+                Bukkit.getServer().getConsoleSender().sendMessage("Functionality will be unstable/not work, and you will get no support");
+            } else {
+                throw new PluginEnableException("Holographic Displays only supports Spigot from 1.8 to 1.19.2.");
+            }
         } catch (OutdatedVersionException e) {
             throw new PluginEnableException("Holographic Displays only supports " + e.getMinimumSupportedVersion() + " and above.");
         } catch (Throwable t) {

--- a/plugin/src/main/java/me/filoghost/holographicdisplays/plugin/config/Settings.java
+++ b/plugin/src/main/java/me/filoghost/holographicdisplays/plugin/config/Settings.java
@@ -24,6 +24,7 @@ public class Settings {
     public static boolean quickEditCommands;
     public static DateTimeFormatter timeFormat;
     public static boolean updateNotification;
+    public static boolean runOnLackSupport;
 
     public static boolean placeholderAPIEnabled;
     public static int placeholderAPIDefaultRefreshInternalTicks;

--- a/plugin/src/main/java/me/filoghost/holographicdisplays/plugin/config/Settings.java
+++ b/plugin/src/main/java/me/filoghost/holographicdisplays/plugin/config/Settings.java
@@ -47,6 +47,7 @@ public class Settings {
         quickEditCommands = config.quickEditCommands;
         timeFormat = parseTimeFormatter(config.timeFormat, config.timeZone, errorCollector);
         updateNotification = config.updateNotification;
+        runOnLackSupport = config.runOnLackSupport;
 
         placeholderAPIEnabled = config.placeholderAPIEnabled;
         placeholderAPIDefaultRefreshInternalTicks = config.placeholderAPIDefaultRefreshIntervalTicks;

--- a/plugin/src/main/java/me/filoghost/holographicdisplays/plugin/config/SettingsModel.java
+++ b/plugin/src/main/java/me/filoghost/holographicdisplays/plugin/config/SettingsModel.java
@@ -21,6 +21,9 @@ public class SettingsModel implements MappedConfig {
     @Path("holograms-view-range")
     int viewRange = 48;
 
+    @Path("run-on-unsupported-versions")
+    boolean runOnLackSupport = false;
+
     @Path("quick-edit-commands")
     boolean quickEditCommands = true;
 


### PR DESCRIPTION
Adds a new config option (defaults to false) that, when true, will attempt to load the plugin when running an unsupported version. Also notifies console that functionality may be limited and you won’t get support.