### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/plugin/src/main/java/me/filoghost/holographicdisplays/plugin/lib/nbt/NBTType.java
+++ b/plugin/src/main/java/me/filoghost/holographicdisplays/plugin/lib/nbt/NBTType.java
@@ -15,7 +15,7 @@ package me.filoghost.holographicdisplays.plugin.lib.nbt;
  * </p>
  * <p>
  * For a community maintained documentation of the NBT format and its types, visit the
- * <a href=https://minecraft.gamepedia.com/NBT_format>Minecraft Wiki</a>
+ * <a href=https://minecraft.wiki/w/NBT_format>Minecraft Wiki</a>
  * </p>
  */
 public enum NBTType {


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.