### PR TITLE
Fixed the display of holograms when View-distance is 1

### DIFF
--- a/core/src/main/java/me/filoghost/holographicdisplays/core/tick/TickingTask.java
+++ b/core/src/main/java/me/filoghost/holographicdisplays/core/tick/TickingTask.java
@@ -93,7 +93,7 @@ public class TickingTask implements Runnable {
         }
 
         // Holograms need to disappear before chunks (code taken from Bukkit)
-        int maxViewRange = (Bukkit.getViewDistance() - 1) * 16;
+        int maxViewRange = Math.max((Bukkit.getViewDistance() - 1),1) * 16;
         if (maxViewRange > CoreGlobalConfig.maxViewRange) {
             maxViewRange = CoreGlobalConfig.maxViewRange;
         }


### PR DESCRIPTION
If you set the value view-distance=1 in server.properties, the hologram disappeared when you tried to move.